### PR TITLE
Fix backend Dockerfile layer order

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,10 +1,14 @@
 FROM python:3.11-slim
 
 WORKDIR /app
+
+# Install dependencies first
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt fastapi[all] sqlmodel uvicorn
+
+# Copy application code
 COPY ./app ./app
 
-RUN pip install fastapi[all] sqlmodel uvicorn
-
 ENV PYTHONPATH=/app
-RUN echo "Listing /app:" && ls /app && echo "Listing /app/app:" && ls /app/app
+
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary
- copy requirements before installing dependencies
- install dependencies with --no-cache-dir and from requirements
- copy app after dependencies
- remove debug statements

## Testing
- `docker build -t uncle-jons-bank-backend ./backend` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b91181d208323b3f3e5e9bb7b6007