### PR TITLE
Fix backend requirements for local install

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,2 +1,9 @@
 passlib[bcrypt]
 python-jose[cryptography]
+# Framework and server
+fastapi
+uvicorn
+
+# Database layer
+sqlmodel
+sqlalchemy


### PR DESCRIPTION
## Summary
- add FastAPI and database dependencies in `backend/requirements.txt`

## Testing
- `python -m compileall backend/app`
- `python -m pip install --dry-run -r backend/requirements.txt` *(fails: Cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_688b94f8eef08323ad14623f937d03db