### PR TITLE
Hash passwords on user creation

### DIFF
--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -1,8 +1,11 @@
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 from app.models import User, Child
+from app.auth import get_password_hash
 
 async def create_user(db: AsyncSession, user: User):
+    if not user.password_hash.startswith("$2b$"):
+        user.password_hash = get_password_hash(user.password_hash)
     db.add(user)
     await db.commit()
     await db.refresh(user)

--- a/backend/app/routes/users.py
+++ b/backend/app/routes/users.py
@@ -4,6 +4,7 @@ from app.schemas import UserCreate, UserRead
 from app.models import User
 from app.database import get_session
 from app.crud import create_user, get_user_by_email
+from app.auth import get_password_hash
 
 router = APIRouter(prefix="/users", tags=["users"])
 
@@ -12,5 +13,6 @@ async def create_user_route(user: UserCreate, db: AsyncSession = Depends(get_ses
     existing = await get_user_by_email(db, user.email)
     if existing:
         raise HTTPException(status_code=400, detail="Email already registered")
-    user_model = User(name=user.name, email=user.email, password_hash=user.password)  # Hash later!
+    hashed = get_password_hash(user.password)
+    user_model = User(name=user.name, email=user.email, password_hash=hashed)
     return await create_user(db, user_model)


### PR DESCRIPTION
## Summary
- hash user passwords using app.auth.get_password_hash
- hash again in CRUD helper only if not already hashed

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b9501a2408323925827ca7685bd94