### PR TITLE
Switch to async SQLAlchemy sessions

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,11 +1,23 @@
-from sqlmodel import SQLModel, create_engine, Session
+from sqlmodel import SQLModel
+from sqlalchemy.ext.asyncio import (
+    create_async_engine,
+    AsyncSession,
+    async_sessionmaker,
+)
 
-DATABASE_URL = "sqlite:///./uncle_jons_bank.db"  # swap with Postgres URL if needed
-engine = create_engine(DATABASE_URL, echo=True)
+DATABASE_URL = "sqlite+aiosqlite:///./uncle_jons_bank.db"  # swap with Postgres URL if needed
+engine = create_async_engine(DATABASE_URL, echo=True)
 
-def create_db_and_tables():
+async_session = async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def create_db_and_tables() -> None:
     from .models import User, Child, ChildUserLink, Account, Transaction
-    SQLModel.metadata.create_all(engine)
 
-def get_session():
-    return Session(engine)
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+
+
+async def get_session() -> AsyncSession:
+    async with async_session() as session:
+        yield session

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -14,9 +14,11 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+
 @app.on_event("startup")
-def on_startup():
-    create_db_and_tables()
+async def on_startup():
+    await create_db_and_tables()
+
 
 app.include_router(users.router)
 app.include_router(children.router)

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -1,21 +1,24 @@
 # app/routes/auth.py
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordRequestForm
-from sqlalchemy.orm import Session
-from app.auth import authenticate_user, create_access_token, get_db
+from sqlalchemy.ext.asyncio import AsyncSession
+from app.auth import authenticate_user, create_access_token
+from app.database import get_session
 from datetime import timedelta
 
 router = APIRouter()
 
 
 @router.post("/token")
-def login_for_access_token(
-    form_data: OAuth2PasswordRequestForm = Depends(), db: Session = Depends(get_db)
+async def login_for_access_token(
+    form_data: OAuth2PasswordRequestForm = Depends(),
+    db: AsyncSession = Depends(get_session),
 ):
-    user = authenticate_user(db, form_data.username, form_data.password)
+    user = await authenticate_user(db, form_data.username, form_data.password)
     if not user:
         raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials"
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid credentials",
         )
     access_token = create_access_token(
         data={"sub": user.email}, expires_delta=timedelta(minutes=60)


### PR DESCRIPTION
## Summary
- use async SQLAlchemy engine and session
- add async `get_session()` generator
- update auth helpers and auth route for async DB access
- await database setup on startup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b94f178bc8323816d52408359acb2