### PR TITLE
Refactor schema organization

### DIFF
--- a/backend/app/routes/users.py
+++ b/backend/app/routes/users.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
-from app.schemas import UserCreate, UserRead
+from app.schemas import UserCreate, UserResponse
 from app.models import User
 from app.database import get_session
 from app.crud import create_user, get_user_by_email
@@ -8,7 +8,7 @@ from app.auth import get_password_hash
 
 router = APIRouter(prefix="/users", tags=["users"])
 
-@router.post("/", response_model=UserRead)
+@router.post("/", response_model=UserResponse)
 async def create_user_route(user: UserCreate, db: AsyncSession = Depends(get_session)):
     existing = await get_user_by_email(db, user.email)
     if existing:

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -1,1 +1,9 @@
 from .user import UserCreate, UserResponse
+from .child import ChildCreate, ChildRead
+
+__all__ = [
+    "UserCreate",
+    "UserResponse",
+    "ChildCreate",
+    "ChildRead",
+]

--- a/backend/app/schemas/child.py
+++ b/backend/app/schemas/child.py
@@ -1,15 +1,5 @@
 from pydantic import BaseModel
-from typing import List, Optional
-
-class UserCreate(BaseModel):
-    name: str
-    email: str
-    password: str
-
-class UserRead(BaseModel):
-    id: int
-    name: str
-    email: str
+from typing import Optional
 
 class ChildCreate(BaseModel):
     first_name: str


### PR DESCRIPTION
## Summary
- remove `backend/app/schemas.py`
- add `backend/app/schemas/child.py` for child schemas
- re-export schemas via `backend/app/schemas/__init__.py`
- update user routes to use `UserResponse`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b9c575b108323ba6b33c667117bb8