### PR TITLE
Use from_attributes for Pydantic models

### DIFF
--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -14,4 +14,4 @@ class UserResponse(BaseModel):
     role: str
 
     class Config:
-        orm_mode = True
+        model_config = {"from_attributes": True}


### PR DESCRIPTION
## Summary
- avoid Pydantic v2 warnings by configuring models with `from_attributes`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b9c5c9f3c8323bac9c82aa067bba5