### PR TITLE
Fix /token route login with hashed passwords

### DIFF
--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -2,7 +2,11 @@
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordRequestForm
 from sqlalchemy.ext.asyncio import AsyncSession
-from app.auth import authenticate_user, create_access_token, get_password_hash
+from app.auth import (
+    create_access_token,
+    get_password_hash,
+    verify_password,
+)
 from app.database import get_session
 from app.models import User
 
@@ -18,8 +22,9 @@ async def login_for_access_token(
     form_data: OAuth2PasswordRequestForm = Depends(),
     db: AsyncSession = Depends(get_session),
 ):
-    user = await authenticate_user(db, form_data.username, form_data.password)
-    if not user:
+    result = await db.execute(select(User).where(User.email == form_data.username))
+    user = result.scalar_one_or_none()
+    if not user or not verify_password(form_data.password, user.password_hash):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid credentials",


### PR DESCRIPTION
## Summary
- allow `/token` route to verify hashed passwords

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688ba0c5f4248323a83204851982016c