### PR TITLE
Implement /login endpoint

### DIFF
--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -11,7 +11,7 @@ from app.database import get_session
 from app.models import User
 
 from sqlmodel import select
-from app.schemas.user import UserCreate, UserResponse
+from app.schemas.user import UserCreate, UserResponse, UserLogin
 from datetime import timedelta
 
 router = APIRouter()
@@ -25,6 +25,21 @@ async def login_for_access_token(
     result = await db.execute(select(User).where(User.email == form_data.username))
     user = result.scalar_one_or_none()
     if not user or not verify_password(form_data.password, user.password_hash):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid credentials",
+        )
+    access_token = create_access_token(
+        data={"sub": user.email}, expires_delta=timedelta(minutes=60)
+    )
+    return {"access_token": access_token, "token_type": "bearer"}
+
+
+@router.post("/login")
+async def login(user_in: UserLogin, db: AsyncSession = Depends(get_session)):
+    result = await db.execute(select(User).where(User.email == user_in.email))
+    user = result.scalar_one_or_none()
+    if not user or not verify_password(user_in.password, user.password_hash):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid credentials",

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -33,21 +33,21 @@ async def login_for_access_token(
         data={"sub": user.email}, expires_delta=timedelta(minutes=60)
     )
     return {"access_token": access_token, "token_type": "bearer"}
+@router.post("/token")
+async def login_for_access_token(
+    form_data: OAuth2PasswordRequestForm = Depends(),
+    db: AsyncSession = Depends(get_session),
+):
+    return await authenticate_user(
+        email=form_data.username, password=form_data.password, db=db
+    )
 
 
 @router.post("/login")
 async def login(user_in: UserLogin, db: AsyncSession = Depends(get_session)):
-    result = await db.execute(select(User).where(User.email == user_in.email))
-    user = result.scalar_one_or_none()
-    if not user or not verify_password(user_in.password, user.password_hash):
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid credentials",
-        )
-    access_token = create_access_token(
-        data={"sub": user.email}, expires_delta=timedelta(minutes=60)
+    return await authenticate_user(
+        email=user_in.email, password=user_in.password, db=db
     )
-    return {"access_token": access_token, "token_type": "bearer"}
 
 @router.post("/register", response_model=UserResponse)
 async def register(user_in: UserCreate, db: AsyncSession = Depends(get_session)):

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -15,3 +15,8 @@ class UserResponse(BaseModel):
 
     class Config:
         model_config = {"from_attributes": True}
+
+
+class UserLogin(BaseModel):
+    email: EmailStr
+    password: str


### PR DESCRIPTION
## Summary
- add a `UserLogin` schema
- implement `/login` route for JWT authentication

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688bb089adf083239f88f0a6b6cfd231