### PR TITLE
Fix parent-child linkage via ChildUserLink

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Built with **FastAPI** and **SQLModel**, the backend provides:
 - `LedgerEntry`: Internal transaction record
 - `AccessCode`: For child login
 - `AccountSettings`: Interest rates, lock flags, etc.
+- `ChildUserLink`: Associates guardians and children (many-to-many)
 
 ### 📡 API Endpoints (sample MVP endpoints)
 - `POST /register`: Create parent account

--- a/backend/app/routes/children.py
+++ b/backend/app/routes/children.py
@@ -1,13 +1,22 @@
 from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 from app.schemas import ChildCreate, ChildRead
-from app.models import Child
+from app.models import Child, User
 from app.database import get_session
-from app.crud import create_child
+from app.crud import create_child_for_user
+from app.auth import get_current_user
 
 router = APIRouter(prefix="/children", tags=["children"])
 
 @router.post("/", response_model=ChildRead)
-async def create_child_route(child: ChildCreate, db: AsyncSession = Depends(get_session)):
-    child_model = Child(**child.dict(), user_id=1)  # TODO: use real user_id later
-    return await create_child(db, child_model)
+async def create_child_route(
+    child: ChildCreate,
+    db: AsyncSession = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+):
+    child_model = Child(
+        first_name=child.first_name,
+        access_code=child.access_code,
+        account_frozen=child.frozen,
+    )
+    return await create_child_for_user(db, child_model, current_user.id)

--- a/backend/app/schemas/child.py
+++ b/backend/app/schemas/child.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from typing import Optional
 
 class ChildCreate(BaseModel):
@@ -9,5 +9,7 @@ class ChildCreate(BaseModel):
 class ChildRead(BaseModel):
     id: int
     first_name: str
-    frozen: bool
-    user_id: int
+    frozen: bool = Field(alias="account_frozen")
+
+    class Config:
+        model_config = {"from_attributes": True}


### PR DESCRIPTION
## Summary
- update README to mention `ChildUserLink` model
- refactor `crud` to create and query children via the link table
- adjust `Child` schema
- link children to currently authenticated parent in `/children`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688bb52469f88323a20f7bce9c5af144