### PR TITLE
Implement role-based permissions

### DIFF
--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -63,3 +63,17 @@ async def get_current_user(
     if user is None:
         raise credentials_exception
     return user
+
+
+def require_role(*roles: str):
+    """Dependency factory to require a user role."""
+
+    async def role_dependency(current_user: User = Depends(get_current_user)):
+        if current_user.role not in roles:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Insufficient permissions",
+            )
+        return current_user
+
+    return role_dependency

--- a/backend/app/routes/children.py
+++ b/backend/app/routes/children.py
@@ -4,7 +4,7 @@ from app.schemas import ChildCreate, ChildRead
 from app.models import Child, User
 from app.database import get_session
 from app.crud import create_child_for_user
-from app.auth import get_current_user
+from app.auth import get_current_user, require_role
 
 router = APIRouter(prefix="/children", tags=["children"])
 
@@ -12,7 +12,7 @@ router = APIRouter(prefix="/children", tags=["children"])
 async def create_child_route(
     child: ChildCreate,
     db: AsyncSession = Depends(get_session),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role("parent", "admin")),
 ):
     child_model = Child(
         first_name=child.first_name,

--- a/backend/app/routes/users.py
+++ b/backend/app/routes/users.py
@@ -4,12 +4,16 @@ from app.schemas import UserCreate, UserResponse
 from app.models import User
 from app.database import get_session
 from app.crud import create_user, get_user_by_email
-from app.auth import get_password_hash
+from app.auth import get_password_hash, require_role
 
 router = APIRouter(prefix="/users", tags=["users"])
 
 @router.post("/", response_model=UserResponse)
-async def create_user_route(user: UserCreate, db: AsyncSession = Depends(get_session)):
+async def create_user_route(
+    user: UserCreate,
+    db: AsyncSession = Depends(get_session),
+    current_user: User = Depends(require_role("admin")),
+):
     existing = await get_user_by_email(db, user.email)
     if existing:
         raise HTTPException(status_code=400, detail="Email already registered")


### PR DESCRIPTION
## Summary
- add `require_role` helper in auth layer
- enforce role checks for child creation and user creation endpoints

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688bc56f6bac8323bbf23c6e1270a643