### PR TITLE
Add child account management endpoints and UI

### DIFF
--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -95,8 +95,7 @@ async def get_current_child(
         child_id = int(sub.split(":", 1)[1])
     except (JWTError, ValueError):
         raise credentials_exception
-    result = await db.execute(select(Child).where(Child.id == child_id))
-    child = result.scalar_one_or_none()
+    child = await get_child_by_id(db, child_id)
     if child is None:
         raise credentials_exception
     return child

--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -4,7 +4,7 @@ from jose import JWTError, jwt
 from passlib.context import CryptContext
 from fastapi import Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordBearer
-from app.models import User
+from app.models import User, Child
 from app.database import get_session
 from sqlalchemy.ext.asyncio import AsyncSession
 import os
@@ -77,3 +77,26 @@ def require_role(*roles: str):
         return current_user
 
     return role_dependency
+
+
+async def get_current_child(
+    token: str = Depends(oauth2_scheme),
+    db: AsyncSession = Depends(get_session),
+):
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Could not validate credentials",
+    )
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        sub: str = payload.get("sub")
+        if not sub or not sub.startswith("child:"):
+            raise credentials_exception
+        child_id = int(sub.split(":", 1)[1])
+    except (JWTError, ValueError):
+        raise credentials_exception
+    result = await db.execute(select(Child).where(Child.id == child_id))
+    child = result.scalar_one_or_none()
+    if child is None:
+        raise credentials_exception
+    return child

--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -40,3 +40,13 @@ async def get_children_by_user(db: AsyncSession, user_id: int):
     )
     result = await db.execute(query)
     return result.scalars().all()
+
+
+async def get_child_by_id(db: AsyncSession, child_id: int):
+    result = await db.execute(select(Child).where(Child.id == child_id))
+    return result.scalar_one_or_none()
+
+
+async def get_child_by_access_code(db: AsyncSession, access_code: str):
+    result = await db.execute(select(Child).where(Child.access_code == access_code))
+    return result.scalar_one_or_none()

--- a/backend/app/routes/children.py
+++ b/backend/app/routes/children.py
@@ -1,10 +1,20 @@
-from fastapi import APIRouter, Depends
+from datetime import timedelta
+from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
-from app.schemas import ChildCreate, ChildRead
+from app.schemas import ChildCreate, ChildRead, ChildLogin
 from app.models import Child, User
 from app.database import get_session
-from app.crud import create_child_for_user
-from app.auth import get_current_user, require_role
+from app.crud import (
+    create_child_for_user,
+    get_children_by_user,
+    get_child_by_id,
+    get_child_by_access_code,
+)
+from app.auth import (
+    get_current_user,
+    require_role,
+    create_access_token,
+)
 
 router = APIRouter(prefix="/children", tags=["children"])
 
@@ -14,9 +24,50 @@ async def create_child_route(
     db: AsyncSession = Depends(get_session),
     current_user: User = Depends(require_role("parent", "admin")),
 ):
+    existing = await get_child_by_access_code(db, child.access_code)
+    if existing:
+        raise HTTPException(status_code=400, detail="Access code already in use")
     child_model = Child(
         first_name=child.first_name,
         access_code=child.access_code,
         account_frozen=child.frozen,
     )
     return await create_child_for_user(db, child_model, current_user.id)
+
+
+@router.get("/", response_model=list[ChildRead])
+async def list_children(
+    db: AsyncSession = Depends(get_session),
+    current_user: User = Depends(require_role("parent", "admin")),
+):
+    return await get_children_by_user(db, current_user.id)
+
+
+@router.get("/{child_id}", response_model=ChildRead)
+async def get_child_route(
+    child_id: int,
+    db: AsyncSession = Depends(get_session),
+    current_user: User = Depends(require_role("parent", "admin")),
+):
+    child = await get_child_by_id(db, child_id)
+    if not child:
+        raise HTTPException(status_code=404, detail="Child not found")
+    if current_user.role != "admin":
+        children = await get_children_by_user(db, current_user.id)
+        if child_id not in [c.id for c in children]:
+            raise HTTPException(status_code=404, detail="Child not found")
+    return child
+
+
+@router.post("/login")
+async def child_login(
+    credentials: ChildLogin,
+    db: AsyncSession = Depends(get_session),
+):
+    child = await get_child_by_access_code(db, credentials.access_code)
+    if not child:
+        raise HTTPException(status_code=401, detail="Invalid access code")
+    token = create_access_token(
+        data={"sub": f"child:{child.id}"}, expires_delta=timedelta(minutes=60)
+    )
+    return {"access_token": token, "token_type": "bearer"}

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -1,9 +1,10 @@
 from .user import UserCreate, UserResponse
-from .child import ChildCreate, ChildRead
+from .child import ChildCreate, ChildRead, ChildLogin
 
 __all__ = [
     "UserCreate",
     "UserResponse",
     "ChildCreate",
     "ChildRead",
+    "ChildLogin",
 ]

--- a/backend/app/schemas/child.py
+++ b/backend/app/schemas/child.py
@@ -13,3 +13,7 @@ class ChildRead(BaseModel):
 
     class Config:
         model_config = {"from_attributes": True}
+
+
+class ChildLogin(BaseModel):
+    access_code: str

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -50,21 +50,30 @@ function App() {
         </ul>
         <form onSubmit={async e => {
           e.preventDefault()
-          const resp = await fetch(`${apiUrl}/children`, {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-              Authorization: `Bearer ${token}`
-            },
-            body: JSON.stringify({ first_name: firstName, access_code: accessCode })
-          })
-          if (resp.ok) {
-            setFirstName('')
-            setAccessCode('')
-            fetchChildren()
+          setErrorMessage(null) // Clear any previous error message
+          try {
+            const resp = await fetch(`${apiUrl}/children`, {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+                Authorization: `Bearer ${token}`
+              },
+              body: JSON.stringify({ first_name: firstName, access_code: accessCode })
+            })
+            if (resp.ok) {
+              setFirstName('')
+              setAccessCode('')
+              fetchChildren()
+            } else {
+              const errorData = await resp.json()
+              setErrorMessage(errorData.message || 'Failed to add child. Please try again.')
+            }
+          } catch (error) {
+            setErrorMessage('An unexpected error occurred. Please try again.')
           }
         }}>
           <h4>Add Child</h4>
+          {errorMessage && <p className="error">{errorMessage}</p>}
           <input placeholder="First name" value={firstName} onChange={e => setFirstName(e.target.value)} required />
           <input placeholder="Access code" value={accessCode} onChange={e => setAccessCode(e.target.value)} required />
           <button type="submit">Add</button>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,9 +1,24 @@
-import { useState } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import LoginPage from './LoginPage'
 import './App.css'
 
 function App() {
   const [token, setToken] = useState<string | null>(() => localStorage.getItem('token'))
+  const [children, setChildren] = useState<Array<{id:number, first_name:string}>>([])
+  const [firstName, setFirstName] = useState('')
+  const [accessCode, setAccessCode] = useState('')
+
+  const apiUrl = import.meta.env.VITE_API_URL || 'http://localhost:8000'
+
+  const fetchChildren = useCallback(async () => {
+    if (!token) return
+    const resp = await fetch(`${apiUrl}/children`, {
+      headers: { Authorization: `Bearer ${token}` }
+    })
+    if (resp.ok) {
+      setChildren(await resp.json())
+    }
+  }, [token, apiUrl])
 
   const handleLogin = (tok: string) => {
     setToken(tok)
@@ -14,6 +29,10 @@ function App() {
     localStorage.removeItem('token')
   }
 
+  useEffect(() => {
+    fetchChildren()
+  }, [token, fetchChildren])
+
   if (!token) {
     return <LoginPage onLogin={handleLogin} />
   }
@@ -22,6 +41,35 @@ function App() {
     <div id="app">
       <h1>Uncle Jon's Bank</h1>
       <p>You are logged in.</p>
+      <div>
+        <h3>Your Children</h3>
+        <ul>
+          {children.map(c => (
+            <li key={c.id}>{c.first_name}</li>
+          ))}
+        </ul>
+        <form onSubmit={async e => {
+          e.preventDefault()
+          const resp = await fetch(`${apiUrl}/children`, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              Authorization: `Bearer ${token}`
+            },
+            body: JSON.stringify({ first_name: firstName, access_code: accessCode })
+          })
+          if (resp.ok) {
+            setFirstName('')
+            setAccessCode('')
+            fetchChildren()
+          }
+        }}>
+          <h4>Add Child</h4>
+          <input placeholder="First name" value={firstName} onChange={e => setFirstName(e.target.value)} required />
+          <input placeholder="Access code" value={accessCode} onChange={e => setAccessCode(e.target.value)} required />
+          <button type="submit">Add</button>
+        </form>
+      </div>
       <button onClick={handleLogout}>Logout</button>
     </div>
   )

--- a/frontend/src/LoginPage.tsx
+++ b/frontend/src/LoginPage.tsx
@@ -5,40 +5,56 @@ interface Props {
 }
 
 export default function LoginPage({ onLogin }: Props) {
+  const [isChild, setIsChild] = useState(false)
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
+  const [accessCode, setAccessCode] = useState('')
   const [error, setError] = useState('')
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     setError('')
     try {
-      const resp = await fetch(`${import.meta.env.VITE_API_URL || 'http://localhost:8000'}/login`, {
+      const url = `${import.meta.env.VITE_API_URL || 'http://localhost:8000'}` + (isChild ? '/children/login' : '/login')
+      const body = isChild ? { access_code: accessCode } : { email, password }
+      const resp = await fetch(url, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email, password })
+        body: JSON.stringify(body)
       })
       if (!resp.ok) throw new Error('Login failed')
       const data = await resp.json()
       onLogin(data.access_token)
       localStorage.setItem('token', data.access_token)
     } catch {
-      setError('Invalid email or password')
+      setError('Invalid credentials')
     }
   }
 
   return (
     <div>
       <h2>Login</h2>
+      <button onClick={() => setIsChild(!isChild)} style={{ marginBottom: '1em' }}>
+        {isChild ? 'Switch to Parent Login' : 'Switch to Child Login'}
+      </button>
       <form onSubmit={handleSubmit}>
-        <div>
-          <label>Email:</label>
-          <input type="email" value={email} onChange={e => setEmail(e.target.value)} required />
-        </div>
-        <div>
-          <label>Password:</label>
-          <input type="password" value={password} onChange={e => setPassword(e.target.value)} required />
-        </div>
+        {isChild ? (
+          <div>
+            <label>Access Code:</label>
+            <input value={accessCode} onChange={e => setAccessCode(e.target.value)} required />
+          </div>
+        ) : (
+          <>
+            <div>
+              <label>Email:</label>
+              <input type="email" value={email} onChange={e => setEmail(e.target.value)} required />
+            </div>
+            <div>
+              <label>Password:</label>
+              <input type="password" value={password} onChange={e => setPassword(e.target.value)} required />
+            </div>
+          </>
+        )}
         <button type="submit">Login</button>
       </form>
       {error && <p style={{ color: 'red' }}>{error}</p>}


### PR DESCRIPTION
## Summary
- add child CRUD helpers
- expose `/children` list, detail, login routes
- ensure access codes are unique
- implement child login flow on frontend
- show and add children on parent home screen

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688bc70f2c508323b5423494a5e2c0b2