### PR TITLE
Add child import to auth

### DIFF
--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -6,6 +6,7 @@ from fastapi import Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordBearer
 from app.models import User, Child
 from app.database import get_session
+from app.crud import get_child_by_id
 from sqlalchemy.ext.asyncio import AsyncSession
 import os
 


### PR DESCRIPTION
## Summary
- add child retrieval helper to `backend/app/auth.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688bcc107f148323b7ee5f50d8b3ef1e