### PR TITLE
Add error styling

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -40,3 +40,8 @@
 .read-the-docs {
   color: #888;
 }
+
+.error {
+  color: red;
+  margin-top: 0.5em;
+}


### PR DESCRIPTION
## Summary
- style `.error` messages in red with a small margin for better UI clarity

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688bcc171e6083239504a46cc73092d1