### PR TITLE
Add child account freeze feature

### DIFF
--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -50,3 +50,15 @@ async def get_child_by_id(db: AsyncSession, child_id: int):
 async def get_child_by_access_code(db: AsyncSession, access_code: str):
     result = await db.execute(select(Child).where(Child.access_code == access_code))
     return result.scalar_one_or_none()
+
+
+async def set_child_frozen(db: AsyncSession, child_id: int, frozen: bool) -> Child | None:
+    result = await db.execute(select(Child).where(Child.id == child_id))
+    child = result.scalar_one_or_none()
+    if not child:
+        return None
+    child.account_frozen = frozen
+    db.add(child)
+    await db.commit()
+    await db.refresh(child)
+    return child

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,7 +4,7 @@ import './App.css'
 
 function App() {
   const [token, setToken] = useState<string | null>(() => localStorage.getItem('token'))
-  const [children, setChildren] = useState<Array<{id:number, first_name:string}>>([])
+  const [children, setChildren] = useState<Array<{id:number, first_name:string, frozen:boolean}>>([])
   const [firstName, setFirstName] = useState('')
   const [accessCode, setAccessCode] = useState('')
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
@@ -20,6 +20,16 @@ function App() {
       setChildren(await resp.json())
     }
   }, [token, apiUrl])
+
+  const toggleFreeze = async (childId: number, frozen: boolean) => {
+    if (!token) return
+    const endpoint = frozen ? 'unfreeze' : 'freeze'
+    await fetch(`${apiUrl}/children/${childId}/${endpoint}`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` }
+    })
+    fetchChildren()
+  }
 
   const handleLogin = (tok: string) => {
     setToken(tok)
@@ -46,7 +56,12 @@ function App() {
         <h3>Your Children</h3>
         <ul>
           {children.map(c => (
-            <li key={c.id}>{c.first_name}</li>
+            <li key={c.id}>
+              {c.first_name} {c.frozen && '(Frozen)'}
+              <button onClick={() => toggleFreeze(c.id, c.frozen)} style={{ marginLeft: '1em' }}>
+                {c.frozen ? 'Unfreeze' : 'Freeze'}
+              </button>
+            </li>
           ))}
         </ul>
         <form onSubmit={async e => {

--- a/frontend/src/LoginPage.tsx
+++ b/frontend/src/LoginPage.tsx
@@ -22,12 +22,21 @@ export default function LoginPage({ onLogin }: Props) {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body)
       })
-      if (!resp.ok) throw new Error('Login failed')
+      if (!resp.ok) {
+        if (resp.status === 403) {
+          throw new Error('Account frozen')
+        }
+        throw new Error('Login failed')
+      }
       const data = await resp.json()
       onLogin(data.access_token)
       localStorage.setItem('token', data.access_token)
-    } catch {
-      setError('Invalid credentials')
+    } catch (err: unknown) {
+      if (err instanceof Error) {
+        setError(err.message)
+      } else {
+        setError('Invalid credentials')
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- prevent child login when account frozen
- provide API endpoints to freeze or unfreeze child accounts
- add account freeze UI controls in React app
- show error message if a frozen child tries to log in

## Testing
- `npm run lint`
- `python -m compileall backend/app`

------
https://chatgpt.com/codex/tasks/task_e_688bd68564b483238529b79c7bd8c3aa