### PR TITLE
Add ledger viewing UI and refine transactions API

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from app.routes import users, children, auth
+from app.routes import users, children, auth, transactions
 from app.database import create_db_and_tables
 
 app = FastAPI()
@@ -23,6 +23,7 @@ async def on_startup():
 app.include_router(users.router)
 app.include_router(children.router)
 app.include_router(auth.router)
+app.include_router(transactions.router)
 
 
 @app.get("/")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -22,6 +22,7 @@ class Child(SQLModel, table=True):
 
     parents: List["ChildUserLink"] = Relationship(back_populates="child")
     account: Optional["Account"] = Relationship(back_populates="child")
+    transactions: List["Transaction"] = Relationship(back_populates="child")
 
 
 class ChildUserLink(SQLModel, table=True):
@@ -40,19 +41,18 @@ class Account(SQLModel, table=True):
     last_interest_applied: Optional[date] = None
 
     child: Child = Relationship(back_populates="account")
-    transactions: List["Transaction"] = Relationship(back_populates="account")
 
 
 class Transaction(SQLModel, table=True):
-    id: Optional[int] = Field(default=None, primary_key=True)
-    account_id: int = Field(foreign_key="account.id")
-    amount: float
-    type: str  # deposit, withdrawal, interest, penalty, bonus
-    memo: Optional[str] = None
-    created_by: Optional[int] = Field(default=None, foreign_key="user.id")
-    date: datetime = Field(default_factory=datetime.utcnow)
-    promotion_id: Optional[int] = Field(default=None)
-    status: str = "approved"  # pending, approved, denied
-    denial_reason: Optional[str] = None
+    """Ledger transaction representing credits and debits on a child's account."""
 
-    account: Account = Relationship(back_populates="transactions")
+    id: Optional[int] = Field(default=None, primary_key=True, alias="transaction_id")
+    child_id: int = Field(foreign_key="child.id")
+    type: str  # "credit" or "debit"
+    amount: float
+    memo: Optional[str] = None
+    initiated_by: str  # "child" or "parent"
+    initiator_id: int
+    timestamp: datetime = Field(default_factory=datetime.utcnow)
+
+    child: Child = Relationship(back_populates="transactions")

--- a/backend/app/routes/transactions.py
+++ b/backend/app/routes/transactions.py
@@ -1,0 +1,30 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+from app.database import get_session
+from app.models import Transaction
+from app.schemas import TransactionCreate, TransactionRead, LedgerResponse
+from app.crud import create_transaction, get_transactions_by_child, calculate_balance
+
+router = APIRouter(prefix="/transactions", tags=["transactions"])
+
+
+@router.post("/", response_model=TransactionRead)
+async def add_transaction(transaction: TransactionCreate, db: AsyncSession = Depends(get_session)):
+    tx_model = Transaction(
+        child_id=transaction.child_id,
+        type=transaction.type,
+        amount=transaction.amount,
+        memo=transaction.memo,
+        initiated_by=transaction.initiated_by,
+        initiator_id=transaction.initiator_id,
+    )
+    return await create_transaction(db, tx_model)
+
+
+@router.get("/child/{child_id}", response_model=LedgerResponse)
+async def get_ledger(child_id: int, db: AsyncSession = Depends(get_session)):
+    transactions = await get_transactions_by_child(db, child_id)
+    balance = await calculate_balance(db, child_id)
+    return {"balance": balance, "transactions": transactions}

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -1,5 +1,10 @@
 from .user import UserCreate, UserResponse
 from .child import ChildCreate, ChildRead, ChildLogin
+from .transaction import (
+    TransactionCreate,
+    TransactionRead,
+    LedgerResponse,
+)
 
 __all__ = [
     "UserCreate",
@@ -7,4 +12,7 @@ __all__ = [
     "ChildCreate",
     "ChildRead",
     "ChildLogin",
+    "TransactionCreate",
+    "TransactionRead",
+    "LedgerResponse",
 ]

--- a/backend/app/schemas/transaction.py
+++ b/backend/app/schemas/transaction.py
@@ -1,0 +1,29 @@
+from pydantic import BaseModel, Field
+from typing import Optional
+from datetime import datetime
+
+
+class TransactionBase(BaseModel):
+    child_id: int
+    type: str
+    amount: float
+    memo: Optional[str] = None
+    initiated_by: str
+    initiator_id: int
+
+
+class TransactionCreate(TransactionBase):
+    pass
+
+
+class TransactionRead(TransactionBase):
+    transaction_id: int = Field(alias="id")
+    timestamp: datetime
+
+    class Config:
+        model_config = {"from_attributes": True}
+
+
+class LedgerResponse(BaseModel):
+    balance: float
+    transactions: list[TransactionRead]

--- a/frontend/src/LoginPage.tsx
+++ b/frontend/src/LoginPage.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 
 interface Props {
-  onLogin: (token: string) => void
+  onLogin: (token: string, isChild: boolean) => void
 }
 
 export default function LoginPage({ onLogin }: Props) {
@@ -29,8 +29,7 @@ export default function LoginPage({ onLogin }: Props) {
         throw new Error('Login failed')
       }
       const data = await resp.json()
-      onLogin(data.access_token)
-      localStorage.setItem('token', data.access_token)
+      onLogin(data.access_token, isChild)
     } catch (err: unknown) {
       if (err instanceof Error) {
         setError(err.message)


### PR DESCRIPTION
## Summary
- extend LoginPage onLogin API with child flag
- implement ledger viewing for parents and children in App
- show account ledger for selected child
- clean up transactions API and balance calculation

## Testing
- `python -m py_compile backend/app/*.py backend/app/routes/*.py backend/app/schemas/*.py`
- `pytest -q`
- `npm --prefix frontend run build`


------
https://chatgpt.com/codex/tasks/task_e_688bda6d9c4483239ad1f4fb1432b9bb