### PR TITLE
Fix freeze button detection

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -29,6 +29,13 @@ interface WithdrawalRequest {
   denial_reason?: string | null
 }
 
+interface ChildApi {
+  id: number
+  first_name: string
+  account_frozen?: boolean
+  frozen?: boolean
+}
+
 function App() {
   const [token, setToken] = useState<string | null>(() => localStorage.getItem('token'))
   const [isChildAccount, setIsChildAccount] = useState<boolean>(() => localStorage.getItem('isChild') === 'true')
@@ -58,7 +65,14 @@ function App() {
       headers: { Authorization: `Bearer ${token}` }
     })
     if (resp.ok) {
-      setChildren(await resp.json())
+      const data: ChildApi[] = await resp.json()
+      setChildren(
+        data.map(c => ({
+          id: c.id,
+          first_name: c.first_name,
+          frozen: c.frozen ?? c.account_frozen ?? false
+        }))
+      )
     }
   }, [token, apiUrl])
 


### PR DESCRIPTION
## Summary
- map frozen status from API correctly
- add type for Child API response

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688c170c267883238eafbbf7c9c5a7ee