### PR TITLE
Implement daily interest accrual

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -23,7 +23,9 @@ class Child(SQLModel, table=True):
     parents: List["ChildUserLink"] = Relationship(back_populates="child")
     account: Optional["Account"] = Relationship(back_populates="child")
     transactions: List["Transaction"] = Relationship(back_populates="child")
-    withdrawal_requests: List["WithdrawalRequest"] = Relationship(back_populates="child")
+    withdrawal_requests: List["WithdrawalRequest"] = Relationship(
+        back_populates="child"
+    )
 
 
 class ChildUserLink(SQLModel, table=True):
@@ -40,6 +42,7 @@ class Account(SQLModel, table=True):
     balance: float = 0.0
     interest_rate: float = 0.01  # Daily rate (e.g., 0.01 = 1%)
     last_interest_applied: Optional[date] = None
+    total_interest_earned: float = 0.0
 
     child: Child = Relationship(back_populates="account")
 

--- a/backend/app/routes/transactions.py
+++ b/backend/app/routes/transactions.py
@@ -17,13 +17,16 @@ from app.crud import (
     get_transaction,
     save_transaction,
     delete_transaction,
+    recalc_interest,
 )
 
 router = APIRouter(prefix="/transactions", tags=["transactions"])
 
 
 @router.post("/", response_model=TransactionRead)
-async def add_transaction(transaction: TransactionCreate, db: AsyncSession = Depends(get_session)):
+async def add_transaction(
+    transaction: TransactionCreate, db: AsyncSession = Depends(get_session)
+):
     tx_model = Transaction(
         child_id=transaction.child_id,
         type=transaction.type,
@@ -32,7 +35,9 @@ async def add_transaction(transaction: TransactionCreate, db: AsyncSession = Dep
         initiated_by=transaction.initiated_by,
         initiator_id=transaction.initiator_id,
     )
-    return await create_transaction(db, tx_model)
+    new_tx = await create_transaction(db, tx_model)
+    await recalc_interest(db, transaction.child_id)
+    return new_tx
 
 
 @router.put("/{transaction_id}", response_model=TransactionRead)
@@ -47,6 +52,7 @@ async def update_transaction_route(
     for field, value in data.model_dump(exclude_unset=True).items():
         setattr(tx, field, value)
     updated = await save_transaction(db, tx)
+    await recalc_interest(db, tx.child_id)
     return updated
 
 
@@ -59,6 +65,7 @@ async def delete_transaction_route(
     if not tx:
         raise HTTPException(status_code=404, detail="Transaction not found")
     await delete_transaction(db, tx)
+    await recalc_interest(db, tx.child_id)
 
 
 @router.get("/child/{child_id}", response_model=LedgerResponse)

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -1,5 +1,5 @@
 from .user import UserCreate, UserResponse
-from .child import ChildCreate, ChildRead, ChildLogin
+from .child import ChildCreate, ChildRead, ChildLogin, InterestRateUpdate
 from .transaction import (
     TransactionCreate,
     TransactionRead,
@@ -18,6 +18,7 @@ __all__ = [
     "ChildCreate",
     "ChildRead",
     "ChildLogin",
+    "InterestRateUpdate",
     "TransactionCreate",
     "TransactionRead",
     "TransactionUpdate",

--- a/backend/app/schemas/child.py
+++ b/backend/app/schemas/child.py
@@ -1,15 +1,19 @@
 from pydantic import BaseModel, Field
 from typing import Optional
 
+
 class ChildCreate(BaseModel):
     first_name: str
     access_code: str
     frozen: Optional[bool] = False
 
+
 class ChildRead(BaseModel):
     id: int
     first_name: str
     frozen: bool = Field(alias="account_frozen")
+    interest_rate: float | None = None
+    total_interest_earned: float | None = None
 
     class Config:
         model_config = {"from_attributes": True}
@@ -17,3 +21,7 @@ class ChildRead(BaseModel):
 
 class ChildLogin(BaseModel):
     access_code: str
+
+
+class InterestRateUpdate(BaseModel):
+    interest_rate: float


### PR DESCRIPTION
## Summary
- track total interest earned on accounts
- create accounts when children are created
- recalc daily interest whenever ledger changes
- expose interest data and editing endpoints
- display interest rate info in the React UI
- schedule a daily background task to add interest

## Testing
- `npm run lint`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688c1963eba88323ad6885b1f41cdae6