### PR TITLE
Add admin panel endpoints and UI

### DIFF
--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -26,6 +26,28 @@ async def get_user_by_email(db: AsyncSession, email: str):
     return result.scalar_one_or_none()
 
 
+async def get_user(db: AsyncSession, user_id: int) -> User | None:
+    result = await db.execute(select(User).where(User.id == user_id))
+    return result.scalar_one_or_none()
+
+
+async def get_all_users(db: AsyncSession) -> list[User]:
+    result = await db.execute(select(User).order_by(User.id))
+    return result.scalars().all()
+
+
+async def save_user(db: AsyncSession, user: User) -> User:
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+    return user
+
+
+async def delete_user(db: AsyncSession, user: User) -> None:
+    await db.delete(user)
+    await db.commit()
+
+
 async def create_child(db: AsyncSession, child: Child):
     db.add(child)
     await db.commit()
@@ -59,6 +81,28 @@ async def get_children_by_user(db: AsyncSession, user_id: int):
 async def get_child_by_access_code(db: AsyncSession, access_code: str):
     result = await db.execute(select(Child).where(Child.access_code == access_code))
     return result.scalar_one_or_none()
+
+
+async def get_child(db: AsyncSession, child_id: int) -> Child | None:
+    result = await db.execute(select(Child).where(Child.id == child_id))
+    return result.scalar_one_or_none()
+
+
+async def get_all_children(db: AsyncSession) -> list[Child]:
+    result = await db.execute(select(Child).order_by(Child.id))
+    return result.scalars().all()
+
+
+async def save_child(db: AsyncSession, child: Child) -> Child:
+    db.add(child)
+    await db.commit()
+    await db.refresh(child)
+    return child
+
+
+async def delete_child(db: AsyncSession, child: Child) -> None:
+    await db.delete(child)
+    await db.commit()
 
 
 async def set_child_frozen(
@@ -128,6 +172,11 @@ async def get_transactions_by_child(
         .where(Transaction.child_id == child_id)
         .order_by(Transaction.timestamp)
     )
+    return result.scalars().all()
+
+
+async def get_all_transactions(db: AsyncSession) -> list[Transaction]:
+    result = await db.execute(select(Transaction).order_by(Transaction.timestamp))
     return result.scalars().all()
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from app.routes import users, children, auth, transactions, withdrawals
+from app.routes import users, children, auth, transactions, withdrawals, admin
 from app.database import create_db_and_tables, async_session
 from app.crud import recalc_interest
 from app.models import Child
@@ -40,6 +40,7 @@ app.include_router(children.router)
 app.include_router(auth.router)
 app.include_router(transactions.router)
 app.include_router(withdrawals.router)
+app.include_router(admin.router)
 
 
 @app.get("/")

--- a/backend/app/routes/__init__.py
+++ b/backend/app/routes/__init__.py
@@ -1,0 +1,10 @@
+from . import auth, users, children, transactions, withdrawals, admin
+
+__all__ = [
+    "auth",
+    "users",
+    "children",
+    "transactions",
+    "withdrawals",
+    "admin",
+]

--- a/backend/app/routes/admin.py
+++ b/backend/app/routes/admin.py
@@ -1,0 +1,194 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_session
+from app.auth import require_role, get_password_hash
+from app.models import User, Child, Transaction
+from app.schemas import (
+    UserResponse, UserUpdate,
+    ChildRead, ChildUpdate,
+    TransactionRead, TransactionUpdate,
+)
+from app.crud import (
+    get_all_users, get_user, save_user, delete_user,
+    get_all_children, get_child, save_child, delete_child,
+    get_all_transactions, get_transaction, save_transaction, delete_transaction,
+    get_account_by_child,
+)
+
+router = APIRouter(prefix="/admin", tags=["admin"])
+
+
+@router.get("/users", response_model=list[UserResponse])
+async def admin_list_users(
+    db: AsyncSession = Depends(get_session),
+    current_user: User = Depends(require_role("admin")),
+):
+    return await get_all_users(db)
+
+
+@router.get("/users/{user_id}", response_model=UserResponse)
+async def admin_get_user(
+    user_id: int,
+    db: AsyncSession = Depends(get_session),
+    current_user: User = Depends(require_role("admin")),
+):
+    user = await get_user(db, user_id)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    return user
+
+
+@router.put("/users/{user_id}", response_model=UserResponse)
+async def admin_update_user(
+    user_id: int,
+    data: UserUpdate,
+    db: AsyncSession = Depends(get_session),
+    current_user: User = Depends(require_role("admin")),
+):
+    user = await get_user(db, user_id)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    if data.password is not None:
+        user.password_hash = get_password_hash(data.password)
+    for field, value in data.model_dump(exclude_unset=True, exclude={"password"}).items():
+        setattr(user, field, value)
+    return await save_user(db, user)
+
+
+@router.delete("/users/{user_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def admin_delete_user(
+    user_id: int,
+    db: AsyncSession = Depends(get_session),
+    current_user: User = Depends(require_role("admin")),
+):
+    user = await get_user(db, user_id)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    await delete_user(db, user)
+
+
+@router.get("/children", response_model=list[ChildRead])
+async def admin_list_children(
+    db: AsyncSession = Depends(get_session),
+    current_user: User = Depends(require_role("admin")),
+):
+    children = await get_all_children(db)
+    result = []
+    for c in children:
+        account = await get_account_by_child(db, c.id)
+        result.append(
+            ChildRead(
+                id=c.id,
+                first_name=c.first_name,
+                account_frozen=c.account_frozen,
+                interest_rate=account.interest_rate if account else None,
+                total_interest_earned=account.total_interest_earned if account else None,
+            )
+        )
+    return result
+
+
+@router.get("/children/{child_id}", response_model=ChildRead)
+async def admin_get_child(
+    child_id: int,
+    db: AsyncSession = Depends(get_session),
+    current_user: User = Depends(require_role("admin")),
+):
+    child = await get_child(db, child_id)
+    if not child:
+        raise HTTPException(status_code=404, detail="Child not found")
+    account = await get_account_by_child(db, child_id)
+    return ChildRead(
+        id=child.id,
+        first_name=child.first_name,
+        account_frozen=child.account_frozen,
+        interest_rate=account.interest_rate if account else None,
+        total_interest_earned=account.total_interest_earned if account else None,
+    )
+
+
+@router.put("/children/{child_id}", response_model=ChildRead)
+async def admin_update_child(
+    child_id: int,
+    data: ChildUpdate,
+    db: AsyncSession = Depends(get_session),
+    current_user: User = Depends(require_role("admin")),
+):
+    child = await get_child(db, child_id)
+    if not child:
+        raise HTTPException(status_code=404, detail="Child not found")
+    for field, value in data.model_dump(exclude_unset=True).items():
+        if field == "frozen":
+            setattr(child, "account_frozen", value)
+        else:
+            setattr(child, field, value)
+    updated = await save_child(db, child)
+    account = await get_account_by_child(db, child_id)
+    return ChildRead(
+        id=updated.id,
+        first_name=updated.first_name,
+        account_frozen=updated.account_frozen,
+        interest_rate=account.interest_rate if account else None,
+        total_interest_earned=account.total_interest_earned if account else None,
+    )
+
+
+@router.delete("/children/{child_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def admin_delete_child(
+    child_id: int,
+    db: AsyncSession = Depends(get_session),
+    current_user: User = Depends(require_role("admin")),
+):
+    child = await get_child(db, child_id)
+    if not child:
+        raise HTTPException(status_code=404, detail="Child not found")
+    await delete_child(db, child)
+
+
+@router.get("/transactions", response_model=list[TransactionRead])
+async def admin_list_transactions(
+    db: AsyncSession = Depends(get_session),
+    current_user: User = Depends(require_role("admin")),
+):
+    return await get_all_transactions(db)
+
+
+@router.get("/transactions/{transaction_id}", response_model=TransactionRead)
+async def admin_get_transaction(
+    transaction_id: int,
+    db: AsyncSession = Depends(get_session),
+    current_user: User = Depends(require_role("admin")),
+):
+    tx = await get_transaction(db, transaction_id)
+    if not tx:
+        raise HTTPException(status_code=404, detail="Transaction not found")
+    return tx
+
+
+@router.put("/transactions/{transaction_id}", response_model=TransactionRead)
+async def admin_update_transaction(
+    transaction_id: int,
+    data: TransactionUpdate,
+    db: AsyncSession = Depends(get_session),
+    current_user: User = Depends(require_role("admin")),
+):
+    tx = await get_transaction(db, transaction_id)
+    if not tx:
+        raise HTTPException(status_code=404, detail="Transaction not found")
+    for field, value in data.model_dump(exclude_unset=True).items():
+        setattr(tx, field, value)
+    updated = await save_transaction(db, tx)
+    return updated
+
+
+@router.delete("/transactions/{transaction_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def admin_delete_transaction(
+    transaction_id: int,
+    db: AsyncSession = Depends(get_session),
+    current_user: User = Depends(require_role("admin")),
+):
+    tx = await get_transaction(db, transaction_id)
+    if not tx:
+        raise HTTPException(status_code=404, detail="Transaction not found")
+    await delete_transaction(db, tx)

--- a/backend/app/routes/users.py
+++ b/backend/app/routes/users.py
@@ -4,7 +4,7 @@ from app.schemas import UserCreate, UserResponse
 from app.models import User
 from app.database import get_session
 from app.crud import create_user, get_user_by_email
-from app.auth import get_password_hash, require_role
+from app.auth import get_password_hash, require_role, get_current_user
 
 router = APIRouter(prefix="/users", tags=["users"])
 
@@ -20,3 +20,9 @@ async def create_user_route(
     hashed = get_password_hash(user.password)
     user_model = User(name=user.name, email=user.email, password_hash=hashed)
     return await create_user(db, user_model)
+
+
+@router.get("/me", response_model=UserResponse)
+async def read_current_user(current_user: User = Depends(get_current_user)):
+    """Return details for the authenticated user."""
+    return current_user

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -1,5 +1,5 @@
-from .user import UserCreate, UserResponse
-from .child import ChildCreate, ChildRead, ChildLogin, InterestRateUpdate
+from .user import UserCreate, UserResponse, UserUpdate
+from .child import ChildCreate, ChildRead, ChildLogin, InterestRateUpdate, ChildUpdate
 from .transaction import (
     TransactionCreate,
     TransactionRead,
@@ -15,8 +15,10 @@ from .withdrawal import (
 __all__ = [
     "UserCreate",
     "UserResponse",
+    "UserUpdate",
     "ChildCreate",
     "ChildRead",
+    "ChildUpdate",
     "ChildLogin",
     "InterestRateUpdate",
     "TransactionCreate",

--- a/backend/app/schemas/child.py
+++ b/backend/app/schemas/child.py
@@ -25,3 +25,9 @@ class ChildLogin(BaseModel):
 
 class InterestRateUpdate(BaseModel):
     interest_rate: float
+
+
+class ChildUpdate(BaseModel):
+    first_name: str | None = None
+    access_code: str | None = None
+    frozen: bool | None = None

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -20,3 +20,10 @@ class UserResponse(BaseModel):
 class UserLogin(BaseModel):
     email: EmailStr
     password: str
+
+
+class UserUpdate(BaseModel):
+    name: str | None = None
+    email: EmailStr | None = None
+    role: str | None = None
+    password: str | None = None

--- a/frontend/src/AdminPanel.tsx
+++ b/frontend/src/AdminPanel.tsx
@@ -1,0 +1,160 @@
+import { useEffect, useState } from 'react'
+
+interface Props {
+  token: string
+  apiUrl: string
+  onLogout: () => void
+}
+
+interface User {
+  id: number
+  name: string
+  email: string
+  role: string
+}
+
+interface Child {
+  id: number
+  first_name: string
+  account_frozen: boolean
+  interest_rate?: number
+  total_interest_earned?: number
+}
+
+interface Transaction {
+  id: number
+  child_id: number
+  type: string
+  amount: number
+  memo?: string | null
+  initiated_by: string
+  initiator_id: number
+  timestamp: string
+}
+
+export default function AdminPanel({ token, apiUrl, onLogout }: Props) {
+  const [users, setUsers] = useState<User[]>([])
+  const [children, setChildren] = useState<Child[]>([])
+  const [transactions, setTransactions] = useState<Transaction[]>([])
+
+  const fetchData = async () => {
+    const uh = { Authorization: `Bearer ${token}` }
+    const u = await fetch(`${apiUrl}/admin/users`, { headers: uh })
+    if (u.ok) setUsers(await u.json())
+    const c = await fetch(`${apiUrl}/admin/children`, { headers: uh })
+    if (c.ok) setChildren(await c.json())
+    const t = await fetch(`${apiUrl}/admin/transactions`, { headers: uh })
+    if (t.ok) setTransactions(await t.json())
+  }
+
+  useEffect(() => {
+    fetchData()
+  }, [token])
+
+  return (
+    <div className="container">
+      <h1>Admin Panel</h1>
+      <h2>Users</h2>
+      <ul className="list">
+        {users.map(u => (
+          <li key={u.id}>
+            {u.name} ({u.email}) [{u.role}]
+            <button
+              onClick={async () => {
+                const name = window.prompt('Name', u.name)
+                if (name === null) return
+                await fetch(`${apiUrl}/admin/users/${u.id}`, {
+                  method: 'PUT',
+                  headers: {
+                    'Content-Type': 'application/json',
+                    Authorization: `Bearer ${token}`
+                  },
+                  body: JSON.stringify({ name })
+                })
+                fetchData()
+              }}
+              className="ml-1"
+            >
+              Edit
+            </button>
+            <button
+              onClick={async () => {
+                if (!confirm('Delete user?')) return
+                await fetch(`${apiUrl}/admin/users/${u.id}`, {
+                  method: 'DELETE',
+                  headers: { Authorization: `Bearer ${token}` }
+                })
+                fetchData()
+              }}
+              className="ml-05"
+            >
+              Delete
+            </button>
+          </li>
+        ))}
+      </ul>
+      <h2>Children</h2>
+      <ul className="list">
+        {children.map(c => (
+          <li key={c.id}>
+            {c.first_name} {c.account_frozen && '(Frozen)'}
+            <button
+              onClick={async () => {
+                const name = window.prompt('Name', c.first_name)
+                if (name === null) return
+                await fetch(`${apiUrl}/admin/children/${c.id}`, {
+                  method: 'PUT',
+                  headers: {
+                    'Content-Type': 'application/json',
+                    Authorization: `Bearer ${token}`
+                  },
+                  body: JSON.stringify({ first_name: name })
+                })
+                fetchData()
+              }}
+              className="ml-1"
+            >
+              Edit
+            </button>
+            <button
+              onClick={async () => {
+                if (!confirm('Delete child?')) return
+                await fetch(`${apiUrl}/admin/children/${c.id}`, {
+                  method: 'DELETE',
+                  headers: { Authorization: `Bearer ${token}` }
+                })
+                fetchData()
+              }}
+              className="ml-05"
+            >
+              Delete
+            </button>
+          </li>
+        ))}
+      </ul>
+      <h2>Transactions</h2>
+      <ul className="list">
+        {transactions.map(t => (
+          <li key={t.id}>
+            #{t.id} Child {t.child_id} {t.type} {t.amount}
+            {t.memo ? ` (${t.memo})` : ''}
+            <button
+              onClick={async () => {
+                if (!confirm('Delete transaction?')) return
+                await fetch(`${apiUrl}/admin/transactions/${t.id}`, {
+                  method: 'DELETE',
+                  headers: { Authorization: `Bearer ${token}` }
+                })
+                fetchData()
+              }}
+              className="ml-05"
+            >
+              Delete
+            </button>
+          </li>
+        ))}
+      </ul>
+      <button onClick={onLogout}>Logout</button>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add user and child update schemas
- provide utilities in CRUD for admin features
- implement admin API router for user, child, and transaction management
- expose `/users/me` for role checks
- include admin router in app
- create AdminPanel frontend and hook into App

## Testing
- `npm run lint`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688c1cc669d883238f870e7cfe61e415