### PR TITLE
Add dark mode support

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -7,7 +7,7 @@
 
 #app,
 .container {
-  background: #ffffff;
+  background: var(--container-bg);
   padding: 2rem;
   border-radius: 8px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,10 +1,15 @@
 :root {
+  --bg-color: #f5f5f5;
+  --text-color: #213547;
+  --button-bg: #1a1a1a;
+  --container-bg: #ffffff;
+
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
 
-  color: #213547;
-  background-color: #f5f5f5;
+  color: var(--text-color);
+  background-color: var(--bg-color);
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -29,6 +34,8 @@ body {
   padding: 2rem;
   min-width: 320px;
   min-height: 100vh;
+  color: var(--text-color);
+  background-color: var(--bg-color);
 }
 
 h1 {
@@ -43,7 +50,7 @@ button {
   font-size: 1em;
   font-weight: 500;
   font-family: inherit;
-  background-color: #1a1a1a;
+  background-color: var(--button-bg);
   color: white;
   cursor: pointer;
   transition: border-color 0.25s;
@@ -56,12 +63,9 @@ button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    color: rgba(255, 255, 255, 0.87);
-    background-color: #242424;
-  }
-  button {
-    background-color: #1a1a1a;
-  }
+.dark {
+  --bg-color: #242424;
+  --text-color: rgba(255, 255, 255, 0.87);
+  --button-bg: #1a1a1a;
+  --container-bg: #333333;
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,6 +3,17 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
 
+const media = window.matchMedia('(prefers-color-scheme: dark)')
+const applyTheme = (e: MediaQueryList | MediaQueryListEvent) => {
+  if (e.matches) {
+    document.documentElement.classList.add('dark')
+  } else {
+    document.documentElement.classList.remove('dark')
+  }
+}
+applyTheme(media)
+media.addEventListener('change', applyTheme)
+
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <App />


### PR DESCRIPTION
## Summary
- detect OS dark mode preference and add a `dark` class
- define CSS variables and update styles for dark mode

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688c20bf100c8323b31645603e88d5a7