### PR TITLE
Implement ACL permission system

### DIFF
--- a/backend/app/acl.py
+++ b/backend/app/acl.py
@@ -1,0 +1,39 @@
+# ACL constants and helpers
+
+PERM_ADD_TRANSACTION = "add_transaction"
+PERM_VIEW_TRANSACTIONS = "view_transactions"
+PERM_DELETE_TRANSACTION = "delete_transaction"
+PERM_DEPOSIT = "deposit"
+PERM_DEBIT = "debit"
+PERM_ADD_CHILD = "add_child"
+PERM_REMOVE_CHILD = "remove_child"
+PERM_FREEZE_CHILD = "freeze_child"
+
+ALL_PERMISSIONS = [
+    PERM_ADD_TRANSACTION,
+    PERM_VIEW_TRANSACTIONS,
+    PERM_DELETE_TRANSACTION,
+    PERM_DEPOSIT,
+    PERM_DEBIT,
+    PERM_ADD_CHILD,
+    PERM_REMOVE_CHILD,
+    PERM_FREEZE_CHILD,
+]
+
+ROLE_DEFAULT_PERMISSIONS = {
+    "admin": ALL_PERMISSIONS,
+    "parent": [
+        PERM_ADD_TRANSACTION,
+        PERM_VIEW_TRANSACTIONS,
+        PERM_DEPOSIT,
+        PERM_DEBIT,
+        PERM_ADD_CHILD,
+        PERM_REMOVE_CHILD,
+        PERM_FREEZE_CHILD,
+    ],
+    "child": [PERM_VIEW_TRANSACTIONS],
+}
+
+
+def get_default_permissions_for_role(role: str) -> list[str]:
+    return ROLE_DEFAULT_PERMISSIONS.get(role, [])

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -5,14 +5,25 @@ from sqlalchemy.ext.asyncio import (
     async_sessionmaker,
 )
 
-DATABASE_URL = "sqlite+aiosqlite:///./uncle_jons_bank.db"  # swap with Postgres URL if needed
+DATABASE_URL = (
+    "sqlite+aiosqlite:///./uncle_jons_bank.db"  # swap with Postgres URL if needed
+)
 engine = create_async_engine(DATABASE_URL, echo=True)
 
 async_session = async_sessionmaker(engine, expire_on_commit=False)
 
 
 async def create_db_and_tables() -> None:
-    from .models import User, Child, ChildUserLink, Account, Transaction, WithdrawalRequest
+    from .models import (
+        User,
+        Child,
+        ChildUserLink,
+        Account,
+        Transaction,
+        WithdrawalRequest,
+        Permission,
+        UserPermissionLink,
+    )
 
     async with engine.begin() as conn:
         await conn.run_sync(SQLModel.metadata.create_all)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,8 +2,9 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from app.routes import users, children, auth, transactions, withdrawals, admin
 from app.database import create_db_and_tables, async_session
-from app.crud import recalc_interest
+from app.crud import recalc_interest, ensure_permissions_exist
 from app.models import Child
+from app.acl import ALL_PERMISSIONS
 from sqlmodel import select
 import asyncio
 
@@ -22,6 +23,8 @@ app.add_middleware(
 @app.on_event("startup")
 async def on_startup():
     await create_db_and_tables()
+    async with async_session() as session:
+        await ensure_permissions_exist(session, ALL_PERMISSIONS)
     asyncio.create_task(daily_interest_task())
 
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -3,6 +3,23 @@ from datetime import datetime, date
 from sqlmodel import SQLModel, Field, Relationship
 
 
+class Permission(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    name: str
+    user_links: List["UserPermissionLink"] = Relationship(back_populates="permission")
+    users: List["User"] = Relationship(
+        back_populates="permissions", link_model=UserPermissionLink
+    )
+
+
+class UserPermissionLink(SQLModel, table=True):
+    user_id: int = Field(foreign_key="user.id", primary_key=True)
+    permission_id: int = Field(foreign_key="permission.id", primary_key=True)
+
+    user: "User" = Relationship(back_populates="permission_links")
+    permission: Permission = Relationship(back_populates="user_links")
+
+
 class User(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
     name: str
@@ -11,6 +28,10 @@ class User(SQLModel, table=True):
     role: str  # 'viewer', 'depositor', 'withdrawer', 'admin'
 
     children: List["ChildUserLink"] = Relationship(back_populates="user")
+    permission_links: List["UserPermissionLink"] = Relationship(back_populates="user")
+    permissions: List[Permission] = Relationship(
+        back_populates="users", link_model=UserPermissionLink
+    )
 
 
 class Child(SQLModel, table=True):

--- a/backend/app/routes/children.py
+++ b/backend/app/routes/children.py
@@ -18,6 +18,13 @@ from app.auth import (
     get_current_user,
     require_role,
     create_access_token,
+    require_permissions,
+)
+from app.acl import (
+    PERM_ADD_CHILD,
+    PERM_REMOVE_CHILD,
+    PERM_FREEZE_CHILD,
+    PERM_VIEW_TRANSACTIONS,
 )
 
 router = APIRouter(prefix="/children", tags=["children"])
@@ -27,7 +34,7 @@ router = APIRouter(prefix="/children", tags=["children"])
 async def create_child_route(
     child: ChildCreate,
     db: AsyncSession = Depends(get_session),
-    current_user: User = Depends(require_role("parent", "admin")),
+    current_user: User = Depends(require_permissions(PERM_ADD_CHILD)),
 ):
     existing = await get_child_by_access_code(db, child.access_code)
     if existing:
@@ -51,7 +58,7 @@ async def create_child_route(
 @router.get("/", response_model=list[ChildRead])
 async def list_children(
     db: AsyncSession = Depends(get_session),
-    current_user: User = Depends(require_role("parent", "admin")),
+    current_user: User = Depends(require_permissions(PERM_ADD_CHILD)),
 ):
     children = await get_children_by_user(db, current_user.id)
     result = []
@@ -75,7 +82,7 @@ async def list_children(
 async def get_child_route(
     child_id: int,
     db: AsyncSession = Depends(get_session),
-    current_user: User = Depends(require_role("parent", "admin")),
+    current_user: User = Depends(require_permissions(PERM_VIEW_TRANSACTIONS)),
 ):
     child = await get_child_by_id(db, child_id)
     if not child:
@@ -98,7 +105,7 @@ async def get_child_route(
 async def freeze_child(
     child_id: int,
     db: AsyncSession = Depends(get_session),
-    current_user: User = Depends(require_role("parent", "admin")),
+    current_user: User = Depends(require_permissions(PERM_FREEZE_CHILD)),
 ):
     child = await get_child_by_id(db, child_id)
     if not child:
@@ -122,7 +129,7 @@ async def freeze_child(
 async def unfreeze_child(
     child_id: int,
     db: AsyncSession = Depends(get_session),
-    current_user: User = Depends(require_role("parent", "admin")),
+    current_user: User = Depends(require_permissions(PERM_FREEZE_CHILD)),
 ):
     child = await get_child_by_id(db, child_id)
     if not child:

--- a/backend/app/routes/transactions.py
+++ b/backend/app/routes/transactions.py
@@ -3,7 +3,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 
 from app.database import get_session
-from app.models import Transaction
+from app.models import Transaction, User
 from app.schemas import (
     TransactionCreate,
     TransactionRead,
@@ -19,14 +19,42 @@ from app.crud import (
     delete_transaction,
     recalc_interest,
 )
+from app.auth import require_permissions, get_current_user
+from app.acl import (
+    PERM_ADD_TRANSACTION,
+    PERM_VIEW_TRANSACTIONS,
+    PERM_DELETE_TRANSACTION,
+    PERM_DEPOSIT,
+    PERM_DEBIT,
+)
 
 router = APIRouter(prefix="/transactions", tags=["transactions"])
 
 
 @router.post("/", response_model=TransactionRead)
 async def add_transaction(
-    transaction: TransactionCreate, db: AsyncSession = Depends(get_session)
+    transaction: TransactionCreate,
+    db: AsyncSession = Depends(get_session),
+    current_user: User = Depends(require_permissions(PERM_ADD_TRANSACTION)),
 ):
+    user_perm_names = {p.name for p in current_user.permissions}
+    if current_user.role != "admin":
+        if transaction.type == "credit" and PERM_DEPOSIT not in user_perm_names:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN, detail="Insufficient permissions"
+            )
+        if transaction.type == "debit" and PERM_DEBIT not in user_perm_names:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN, detail="Insufficient permissions"
+            )
+
+    if current_user.role != "admin":
+        from app.crud import get_children_by_user
+
+        children = await get_children_by_user(db, current_user.id)
+        if transaction.child_id not in [c.id for c in children]:
+            raise HTTPException(status_code=404, detail="Child not found")
+
     tx_model = Transaction(
         child_id=transaction.child_id,
         type=transaction.type,
@@ -45,6 +73,7 @@ async def update_transaction_route(
     transaction_id: int,
     data: TransactionUpdate,
     db: AsyncSession = Depends(get_session),
+    current_user: User = Depends(require_permissions(PERM_ADD_TRANSACTION)),
 ):
     tx = await get_transaction(db, transaction_id)
     if not tx:
@@ -60,6 +89,7 @@ async def update_transaction_route(
 async def delete_transaction_route(
     transaction_id: int,
     db: AsyncSession = Depends(get_session),
+    current_user: User = Depends(require_permissions(PERM_DELETE_TRANSACTION)),
 ):
     tx = await get_transaction(db, transaction_id)
     if not tx:
@@ -69,7 +99,17 @@ async def delete_transaction_route(
 
 
 @router.get("/child/{child_id}", response_model=LedgerResponse)
-async def get_ledger(child_id: int, db: AsyncSession = Depends(get_session)):
+async def get_ledger(
+    child_id: int,
+    db: AsyncSession = Depends(get_session),
+    current_user: User = Depends(require_permissions(PERM_VIEW_TRANSACTIONS)),
+):
+    if current_user.role != "admin":
+        from app.crud import get_children_by_user
+
+        children = await get_children_by_user(db, current_user.id)
+        if child_id not in [c.id for c in children]:
+            raise HTTPException(status_code=404, detail="Child not found")
     transactions = await get_transactions_by_child(db, child_id)
     balance = await calculate_balance(db, child_id)
     return {"balance": balance, "transactions": transactions}

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -11,6 +11,7 @@ from .withdrawal import (
     WithdrawalRequestRead,
     DenyRequest,
 )
+from .permission import PermissionRead, PermissionsUpdate
 
 __all__ = [
     "UserCreate",
@@ -28,4 +29,6 @@ __all__ = [
     "WithdrawalRequestCreate",
     "WithdrawalRequestRead",
     "DenyRequest",
+    "PermissionRead",
+    "PermissionsUpdate",
 ]

--- a/backend/app/schemas/permission.py
+++ b/backend/app/schemas/permission.py
@@ -1,0 +1,13 @@
+from pydantic import BaseModel
+
+
+class PermissionRead(BaseModel):
+    id: int
+    name: str
+
+    class Config:
+        model_config = {"from_attributes": True}
+
+
+class PermissionsUpdate(BaseModel):
+    permissions: list[str]


### PR DESCRIPTION
## Summary
- add `acl` module defining permission constants and role defaults
- create `Permission` and linking tables in models
- ensure base permissions exist on startup
- manage user permissions via new admin endpoints
- enforce permissions in child and transaction routes

## Testing
- `pytest -q`
- `python -m py_compile backend/app/*.py backend/app/routes/*.py backend/app/schemas/*.py`

------
https://chatgpt.com/codex/tasks/task_e_688cbfdc45dc83239d7d4bbec1d3b521