### PR TITLE
Add ACL permissions and admin management

### DIFF
--- a/backend/app/acl.py
+++ b/backend/app/acl.py
@@ -1,0 +1,58 @@
+from enum import Enum
+from fastapi import Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .database import get_session
+from .auth import get_current_user
+from .models import User
+from .crud import user_has_permission
+
+
+class Permission(str, Enum):
+    ADD_TRANSACTION = "add_transaction"
+    VIEW_TRANSACTIONS = "view_transactions"
+    DELETE_TRANSACTION = "delete_transaction"
+    DEPOSIT = "deposit"
+    DEBIT = "debit"
+    ADD_CHILD = "add_child"
+    REMOVE_CHILD = "remove_child"
+    MANAGE_FREEZE = "manage_freeze"
+
+
+PARENT_DEFAULT_GLOBAL = {Permission.ADD_CHILD, Permission.REMOVE_CHILD}
+PARENT_DEFAULT_CHILD = {
+    Permission.ADD_TRANSACTION,
+    Permission.VIEW_TRANSACTIONS,
+    Permission.DELETE_TRANSACTION,
+    Permission.DEPOSIT,
+    Permission.DEBIT,
+    Permission.MANAGE_FREEZE,
+}
+
+
+def require_permission(permission: Permission):
+    async def dependency(
+        child_id: int | None = None,
+        current_user: User = Depends(get_current_user),
+        db: AsyncSession = Depends(get_session),
+    ) -> User:
+        if current_user.role == "admin":
+            return current_user
+        has_perm = await user_has_permission(db, current_user.id, permission.value, child_id)
+        if not has_perm:
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Insufficient permissions")
+        return current_user
+
+    return dependency
+
+
+async def ensure_permission(
+    user: User,
+    db: AsyncSession,
+    permission: Permission,
+    child_id: int | None = None,
+) -> None:
+    if user.role == "admin":
+        return
+    if not await user_has_permission(db, user.id, permission.value, child_id):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Insufficient permissions")

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -12,7 +12,15 @@ async_session = async_sessionmaker(engine, expire_on_commit=False)
 
 
 async def create_db_and_tables() -> None:
-    from .models import User, Child, ChildUserLink, Account, Transaction, WithdrawalRequest
+    from .models import (
+        User,
+        Child,
+        ChildUserLink,
+        Account,
+        Transaction,
+        WithdrawalRequest,
+        UserPermission,
+    )
 
     async with engine.begin() as conn:
         await conn.run_sync(SQLModel.metadata.create_all)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -75,3 +75,12 @@ class WithdrawalRequest(SQLModel, table=True):
 
     child: Child = Relationship(back_populates="withdrawal_requests")
     approver: Optional[User] = Relationship()
+
+class UserPermission(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    user_id: int = Field(foreign_key="user.id")
+    permission: str
+    child_id: Optional[int] = Field(default=None, foreign_key="child.id")
+
+    user: Optional[User] = Relationship()
+    child: Optional[Child] = Relationship()

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -10,6 +10,8 @@ from app.auth import (
 )
 from app.database import get_session
 from app.models import User
+from app.acl import PARENT_DEFAULT_GLOBAL
+from app.crud import add_user_permission
 
 from sqlmodel import select
 from app.schemas.user import UserCreate, UserResponse, UserLogin
@@ -72,5 +74,8 @@ async def register(user_in: UserCreate, db: AsyncSession = Depends(get_session))
     db.add(new_user)
     await db.commit()
     await db.refresh(new_user)
+
+    for perm in PARENT_DEFAULT_GLOBAL:
+        await add_user_permission(db, new_user.id, perm.value)
 
     return new_user

--- a/backend/app/routes/children.py
+++ b/backend/app/routes/children.py
@@ -14,6 +14,7 @@ from app.crud import (
     get_account_by_child,
     recalc_interest,
 )
+from app.acl import Permission, require_permission
 from app.auth import (
     get_current_user,
     require_role,
@@ -27,7 +28,7 @@ router = APIRouter(prefix="/children", tags=["children"])
 async def create_child_route(
     child: ChildCreate,
     db: AsyncSession = Depends(get_session),
-    current_user: User = Depends(require_role("parent", "admin")),
+    current_user: User = Depends(require_permission(Permission.ADD_CHILD)),
 ):
     existing = await get_child_by_access_code(db, child.access_code)
     if existing:
@@ -98,7 +99,7 @@ async def get_child_route(
 async def freeze_child(
     child_id: int,
     db: AsyncSession = Depends(get_session),
-    current_user: User = Depends(require_role("parent", "admin")),
+    current_user: User = Depends(require_permission(Permission.MANAGE_FREEZE)),
 ):
     child = await get_child_by_id(db, child_id)
     if not child:
@@ -122,7 +123,7 @@ async def freeze_child(
 async def unfreeze_child(
     child_id: int,
     db: AsyncSession = Depends(get_session),
-    current_user: User = Depends(require_role("parent", "admin")),
+    current_user: User = Depends(require_permission(Permission.MANAGE_FREEZE)),
 ):
     child = await get_child_by_id(db, child_id)
     if not child:

--- a/backend/app/routes/transactions.py
+++ b/backend/app/routes/transactions.py
@@ -19,13 +19,16 @@ from app.crud import (
     delete_transaction,
     recalc_interest,
 )
+from app.acl import Permission, require_permission, ensure_permission
 
 router = APIRouter(prefix="/transactions", tags=["transactions"])
 
 
 @router.post("/", response_model=TransactionRead)
 async def add_transaction(
-    transaction: TransactionCreate, db: AsyncSession = Depends(get_session)
+    transaction: TransactionCreate,
+    db: AsyncSession = Depends(get_session),
+    current_user=Depends(require_permission(Permission.ADD_TRANSACTION)),
 ):
     tx_model = Transaction(
         child_id=transaction.child_id,
@@ -34,6 +37,11 @@ async def add_transaction(
         memo=transaction.memo,
         initiated_by=transaction.initiated_by,
         initiator_id=transaction.initiator_id,
+    )
+    await ensure_permission(
+        current_user, db,
+        Permission.DEPOSIT if transaction.type == "credit" else Permission.DEBIT,
+        transaction.child_id,
     )
     new_tx = await create_transaction(db, tx_model)
     await recalc_interest(db, transaction.child_id)
@@ -45,12 +53,19 @@ async def update_transaction_route(
     transaction_id: int,
     data: TransactionUpdate,
     db: AsyncSession = Depends(get_session),
+    current_user=Depends(require_permission(Permission.ADD_TRANSACTION)),
 ):
     tx = await get_transaction(db, transaction_id)
     if not tx:
         raise HTTPException(status_code=404, detail="Transaction not found")
     for field, value in data.model_dump(exclude_unset=True).items():
         setattr(tx, field, value)
+    await ensure_permission(
+        current_user,
+        db,
+        Permission.DEPOSIT if (data.type or tx.type) == "credit" else Permission.DEBIT,
+        tx.child_id,
+    )
     updated = await save_transaction(db, tx)
     await recalc_interest(db, tx.child_id)
     return updated
@@ -60,16 +75,27 @@ async def update_transaction_route(
 async def delete_transaction_route(
     transaction_id: int,
     db: AsyncSession = Depends(get_session),
+    current_user=Depends(require_permission(Permission.DELETE_TRANSACTION)),
 ):
     tx = await get_transaction(db, transaction_id)
     if not tx:
         raise HTTPException(status_code=404, detail="Transaction not found")
+    await ensure_permission(
+        current_user,
+        db,
+        Permission.DEPOSIT if tx.type == "credit" else Permission.DEBIT,
+        tx.child_id,
+    )
     await delete_transaction(db, tx)
     await recalc_interest(db, tx.child_id)
 
 
 @router.get("/child/{child_id}", response_model=LedgerResponse)
-async def get_ledger(child_id: int, db: AsyncSession = Depends(get_session)):
+async def get_ledger(
+    child_id: int,
+    db: AsyncSession = Depends(get_session),
+    current_user=Depends(require_permission(Permission.VIEW_TRANSACTIONS)),
+):
     transactions = await get_transactions_by_child(db, child_id)
     balance = await calculate_balance(db, child_id)
     return {"balance": balance, "transactions": transactions}

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -11,6 +11,7 @@ from .withdrawal import (
     WithdrawalRequestRead,
     DenyRequest,
 )
+from .permission import PermissionCreate, PermissionRead
 
 __all__ = [
     "UserCreate",
@@ -28,4 +29,6 @@ __all__ = [
     "WithdrawalRequestCreate",
     "WithdrawalRequestRead",
     "DenyRequest",
+    "PermissionCreate",
+    "PermissionRead",
 ]

--- a/backend/app/schemas/permission.py
+++ b/backend/app/schemas/permission.py
@@ -1,0 +1,14 @@
+from pydantic import BaseModel
+from typing import Optional
+
+class PermissionCreate(BaseModel):
+    permission: str
+    child_id: Optional[int] = None
+
+class PermissionRead(BaseModel):
+    id: int
+    permission: str
+    child_id: Optional[int] = None
+
+    class Config:
+        model_config = {"from_attributes": True}


### PR DESCRIPTION
## Summary
- implement `acl` module with enumerated permissions and helpers
- store user permissions with new `UserPermission` model
- give parents default permissions when registering and when creating children
- require permissions on transaction and child routes
- expose permission management endpoints in admin API

## Testing
- `python -m py_compile $(git ls-files "*.py")`

------
https://chatgpt.com/codex/tasks/task_e_688cbfdc45dc83239d7d4bbec1d3b521