### PR TITLE
Add penalty interest for negative balances

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -61,7 +61,8 @@ class Account(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
     child_id: int = Field(foreign_key="child.id")
     balance: float = 0.0
-    interest_rate: float = 0.01  # Daily rate (e.g., 0.01 = 1%)
+    interest_rate: float = 0.01  # Daily rate for positive balances
+    penalty_interest_rate: float = 0.02  # Daily rate applied when balance < 0
     last_interest_applied: Optional[date] = None
     total_interest_earned: float = 0.0
 

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -1,5 +1,12 @@
 from .user import UserCreate, UserResponse, UserUpdate
-from .child import ChildCreate, ChildRead, ChildLogin, InterestRateUpdate, ChildUpdate
+from .child import (
+    ChildCreate,
+    ChildRead,
+    ChildLogin,
+    InterestRateUpdate,
+    PenaltyRateUpdate,
+    ChildUpdate,
+)
 from .transaction import (
     TransactionCreate,
     TransactionRead,
@@ -22,6 +29,7 @@ __all__ = [
     "ChildUpdate",
     "ChildLogin",
     "InterestRateUpdate",
+    "PenaltyRateUpdate",
     "TransactionCreate",
     "TransactionRead",
     "TransactionUpdate",

--- a/backend/app/schemas/child.py
+++ b/backend/app/schemas/child.py
@@ -13,6 +13,7 @@ class ChildRead(BaseModel):
     first_name: str
     frozen: bool = Field(alias="account_frozen")
     interest_rate: float | None = None
+    penalty_interest_rate: float | None = None
     total_interest_earned: float | None = None
 
     class Config:
@@ -25,6 +26,10 @@ class ChildLogin(BaseModel):
 
 class InterestRateUpdate(BaseModel):
     interest_rate: float
+
+
+class PenaltyRateUpdate(BaseModel):
+    penalty_interest_rate: float
 
 
 class ChildUpdate(BaseModel):

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -36,6 +36,7 @@ interface ChildApi {
   account_frozen?: boolean
   frozen?: boolean
   interest_rate?: number
+  penalty_interest_rate?: number
   total_interest_earned?: number
 }
 
@@ -108,6 +109,8 @@ function App() {
   const [txMemo, setTxMemo] = useState('')
   const [whatIfDays, setWhatIfDays] = useState('')
   const [whatIfRate, setWhatIfRate] = useState('')
+  const [borrowDays, setBorrowDays] = useState('')
+  const [borrowRate, setBorrowRate] = useState('')
 
   const apiUrl = import.meta.env.VITE_API_URL || 'http://localhost:8000'
 
@@ -135,6 +138,7 @@ function App() {
           first_name: c.first_name,
           frozen: c.frozen ?? c.account_frozen ?? false,
           interest_rate: c.interest_rate,
+          penalty_interest_rate: c.penalty_interest_rate,
           total_interest_earned: c.total_interest_earned
         }))
       )
@@ -217,6 +221,8 @@ function App() {
     setTxMemo('')
     setWhatIfDays('')
     setWhatIfRate('')
+    setBorrowDays('')
+    setBorrowRate('')
     localStorage.removeItem('token')
     localStorage.removeItem('isChild')
     localStorage.removeItem('childId')
@@ -270,27 +276,61 @@ function App() {
                 value={whatIfRate}
                 onChange={e => setWhatIfRate(e.target.value)}
               />
-              {whatIfDays && whatIfRate && (
-                <>
-                  <p>
-                    Interest:{' '}
-                    {(
-                      ledger.balance *
-                      (Math.pow(1 + parseFloat(whatIfRate), Number(whatIfDays)) - 1)
-                    ).toFixed(2)}
-                  </p>
-                  <p>
-                    Total Balance:{' '}
-                    {(
-                      ledger.balance *
-                      Math.pow(1 + parseFloat(whatIfRate), Number(whatIfDays))
-                    ).toFixed(2)}
-                  </p>
-                </>
-              )}
-            </div>
+            {whatIfDays && whatIfRate && (
+              <>
+                <p>
+                  Interest:{' '}
+                  {(
+                    ledger.balance *
+                    (Math.pow(1 + parseFloat(whatIfRate), Number(whatIfDays)) - 1)
+                  ).toFixed(2)}
+                </p>
+                <p>
+                  Total Balance:{' '}
+                  {(
+                    ledger.balance *
+                    Math.pow(1 + parseFloat(whatIfRate), Number(whatIfDays))
+                  ).toFixed(2)}
+                </p>
+              </>
+            )}
           </div>
-        )}
+          <div className="form what-if">
+            <h4>Borrowing</h4>
+            <input
+              type="number"
+              placeholder="Days"
+              value={borrowDays}
+              onChange={e => setBorrowDays(e.target.value)}
+            />
+            <input
+              type="number"
+              step="0.0001"
+              placeholder="Daily penalty rate"
+              value={borrowRate}
+              onChange={e => setBorrowRate(e.target.value)}
+            />
+            {borrowDays && borrowRate && (
+              <>
+                <p>
+                  Interest Charged:{' '}
+                  {(
+                    Math.abs(ledger.balance) *
+                    (Math.pow(1 + parseFloat(borrowRate), Number(borrowDays)) - 1)
+                  ).toFixed(2)}
+                </p>
+                <p>
+                  Total Debt:{' '}
+                  {(
+                    Math.abs(ledger.balance) *
+                    Math.pow(1 + parseFloat(borrowRate), Number(borrowDays))
+                  ).toFixed(2)}
+                </p>
+              </>
+            )}
+          </div>
+        </div>
+      )}
         <form onSubmit={async e => {
           e.preventDefault()
           if (!withdrawAmount) return
@@ -363,6 +403,13 @@ function App() {
                   ).toFixed(4)}
                 </p>
                 <p>
+                  Penalty Interest Rate:{' '}
+                  {(
+                    children.find(c => c.id === selectedChild)?.penalty_interest_rate ??
+                    0
+                  ).toFixed(4)}
+                </p>
+                <p>
                   Total Interest Earned:{' '}
                   {(
                     children.find(c => c.id === selectedChild)?.total_interest_earned ??
@@ -386,6 +433,24 @@ function App() {
                   }}
                 >
                   <button type="submit" className="mb-1">Set Interest Rate</button>
+                </form>
+                <form
+                  onSubmit={async e => {
+                    e.preventDefault()
+                    const rate = window.prompt('New daily penalty rate (e.g. 0.02 for 2%)')
+                    if (!rate) return
+                    await fetch(`${apiUrl}/children/${selectedChild}/penalty-interest-rate`, {
+                      method: 'PUT',
+                      headers: {
+                        'Content-Type': 'application/json',
+                        Authorization: `Bearer ${token}`
+                      },
+                      body: JSON.stringify({ penalty_interest_rate: Number(rate) })
+                    })
+                    fetchChildren()
+                  }}
+                >
+                  <button type="submit" className="mb-1">Set Penalty Rate</button>
                 </form>
               </>
             )}
@@ -460,6 +525,39 @@ function App() {
                       Math.pow(
                         1 + (children.find(c => c.id === selectedChild)?.interest_rate || 0),
                         Number(whatIfDays)
+                      )
+                    ).toFixed(2)}
+                  </p>
+                </>
+              )}
+            </div>
+            <div className="form what-if">
+              <h4>Borrowing</h4>
+              <input
+                type="number"
+                placeholder="Days"
+                value={borrowDays}
+                onChange={e => setBorrowDays(e.target.value)}
+              />
+              {borrowDays && (
+                <>
+                  <p>
+                    Interest Charged:{' '}
+                    {(
+                      Math.abs(ledger.balance) *
+                      (Math.pow(
+                        1 + (children.find(c => c.id === selectedChild)?.penalty_interest_rate || 0),
+                        Number(borrowDays)
+                      ) - 1)
+                    ).toFixed(2)}
+                  </p>
+                  <p>
+                    Total Debt:{' '}
+                    {(
+                      Math.abs(ledger.balance) *
+                      Math.pow(
+                        1 + (children.find(c => c.id === selectedChild)?.penalty_interest_rate || 0),
+                        Number(borrowDays)
                       )
                     ).toFixed(2)}
                   </p>


### PR DESCRIPTION
## Summary
- add `penalty_interest_rate` to account model and API schemas
- support updating penalty interest via new endpoint
- apply penalty interest during interest recalculation
- extend frontend with borrowing calculators and penalty rate controls

## Testing
- `python -m app.tests.api_tests` *(fails: "Transaction creation failed: name 'c2' is not defined")*

------
https://chatgpt.com/codex/tasks/task_e_688cdd96fc288323b3d3a2b5f3421634