### PR TITLE
Add penalty interest for negative balances

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -61,7 +61,8 @@ class Account(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
     child_id: int = Field(foreign_key="child.id")
     balance: float = 0.0
-    interest_rate: float = 0.01  # Daily rate (e.g., 0.01 = 1%)
+    interest_rate: float = 0.01  # Daily rate for positive balances
+    penalty_interest_rate: float = 0.02  # Daily rate applied when balance < 0
     last_interest_applied: Optional[date] = None
     total_interest_earned: float = 0.0
 

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -1,5 +1,12 @@
 from .user import UserCreate, UserResponse, UserUpdate
-from .child import ChildCreate, ChildRead, ChildLogin, InterestRateUpdate, ChildUpdate
+from .child import (
+    ChildCreate,
+    ChildRead,
+    ChildLogin,
+    InterestRateUpdate,
+    PenaltyRateUpdate,
+    ChildUpdate,
+)
 from .transaction import (
     TransactionCreate,
     TransactionRead,
@@ -22,6 +29,7 @@ __all__ = [
     "ChildUpdate",
     "ChildLogin",
     "InterestRateUpdate",
+    "PenaltyRateUpdate",
     "TransactionCreate",
     "TransactionRead",
     "TransactionUpdate",

--- a/backend/app/schemas/child.py
+++ b/backend/app/schemas/child.py
@@ -13,6 +13,7 @@ class ChildRead(BaseModel):
     first_name: str
     frozen: bool = Field(alias="account_frozen")
     interest_rate: float | None = None
+    penalty_interest_rate: float | None = None
     total_interest_earned: float | None = None
 
     class Config:
@@ -25,6 +26,10 @@ class ChildLogin(BaseModel):
 
 class InterestRateUpdate(BaseModel):
     interest_rate: float
+
+
+class PenaltyRateUpdate(BaseModel):
+    penalty_interest_rate: float
 
 
 class ChildUpdate(BaseModel):

--- a/backend/app/tests/api_tests.py
+++ b/backend/app/tests/api_tests.py
@@ -156,9 +156,9 @@ async def run_all_tests(persist: bool = False) -> dict:
 
         try:
             c1 = await create_child(p1_headers, "Child1A", "C1A")
-            await create_child(p1_headers, "Child1B", "C1B")
-            await create_child(p2_headers, "Child2A", "C2A")
-            await create_child(p2_headers, "Child2B", "C2B")
+            c2 = await create_child(p1_headers, "Child1B", "C1B")
+            c3 = await create_child(p2_headers, "Child2A", "C2A")
+            c4 = await create_child(p2_headers, "Child2B", "C2B")
             results.append("Children created")
         except Exception as e:
             results.append(f"Child creation failed: {e}")


### PR DESCRIPTION
## Summary
- add `penalty_interest_rate` to account model and API schemas
- support updating penalty interest via new endpoint
- apply penalty interest during interest recalculation
- extend frontend with borrowing calculators and controls for penalty rate
- fix integration tests and TypeScript types

## Testing
- `PYTHONPATH=backend python -m app.tests.api_tests`
- `npm install && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688cdd96fc288323b3d3a2b5f3421634