### PR TITLE
Add ACL and interest tests

### DIFF
--- a/backend/app/routes/tests.py
+++ b/backend/app/routes/tests.py
@@ -11,8 +11,13 @@ async def run_tests_route(persist: bool = False):
 
 
 @router.post("/interest-test")
-async def interest_test_route(persist: bool = False):
-    """Run interest calculation test."""
+async def interest_test_route(persist: bool = False, days: int = 5):
+    """Run interest calculation test.
+
+    ``days`` controls how far from today the initial transaction is dated. A
+    positive value backdates the starting transaction, while a negative value sets
+    it in the future.
+    """
     from app.tests.interest_tests import run_interest_test
 
-    return await run_interest_test(persist=persist)
+    return await run_interest_test(persist=persist, days=days)

--- a/backend/app/routes/tests.py
+++ b/backend/app/routes/tests.py
@@ -8,3 +8,11 @@ async def run_tests_route(persist: bool = False):
     from app.tests.api_tests import run_all_tests
 
     return await run_all_tests(persist=persist)
+
+
+@router.post("/interest-test")
+async def interest_test_route(persist: bool = False):
+    """Run interest calculation test."""
+    from app.tests.interest_tests import run_interest_test
+
+    return await run_interest_test(persist=persist)

--- a/backend/app/tests/api_tests.py
+++ b/backend/app/tests/api_tests.py
@@ -260,6 +260,21 @@ async def run_all_tests(persist: bool = False) -> dict:
             results.append(f"Child ACL test failed: {e}")
             success = False
 
+        try:
+            # Child1 attempts to request withdrawal for Child2A
+            resp = await client.post(
+                "/withdrawals/",
+                headers=child_headers,
+                json={"amount": 5, "memo": "Test", "child_id": c3},
+            )
+            assert resp.status_code == 200
+            if resp.json()["child_id"] != c1:
+                raise AssertionError("Child request applied to wrong account")
+            results.append("Child withdrawal restricted to own account")
+        except Exception as e:
+            results.append(f"Child withdrawal ACL test failed: {e}")
+            success = False
+
     if not persist:
         app.dependency_overrides.pop(get_session, None)
 

--- a/backend/app/tests/api_tests.py
+++ b/backend/app/tests/api_tests.py
@@ -225,6 +225,41 @@ async def run_all_tests(persist: bool = False) -> dict:
             results.append(f"Admin endpoint test failed: {e}")
             return {"success": False, "details": results}
 
+        # ACL tests
+        try:
+            # Parent1 should not be able to delete Parent2's transaction
+            other_ledger = await client.get(
+                f"/transactions/child/{c3}", headers=p2_headers
+            )
+            assert other_ledger.status_code == 200
+            other_tx = other_ledger.json()["transactions"][0]["id"]
+            resp = await client.delete(
+                f"/transactions/{other_tx}", headers=p1_headers
+            )
+            assert resp.status_code in (403, 404)
+            results.append("Unauthorized deletion blocked")
+        except Exception as e:
+            results.append(f"ACL deletion test failed: {e}")
+            success = False
+
+        try:
+            # Child1 should not view Child2's ledger
+            child_login = await client.post(
+                "/children/login", json={"access_code": "C1A"}
+            )
+            assert child_login.status_code == 200
+            child_headers = {
+                "Authorization": f"Bearer {child_login.json()['access_token']}"
+            }
+            resp = await client.get(
+                f"/transactions/child/{c3}", headers=child_headers
+            )
+            assert resp.status_code == 403
+            results.append("Child cross-account access blocked")
+        except Exception as e:
+            results.append(f"Child ACL test failed: {e}")
+            success = False
+
     if not persist:
         app.dependency_overrides.pop(get_session, None)
 

--- a/backend/app/tests/interest_tests.py
+++ b/backend/app/tests/interest_tests.py
@@ -1,0 +1,115 @@
+from typing import List
+from datetime import datetime, timedelta
+
+from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker, AsyncSession
+from sqlmodel import SQLModel
+
+from app.database import async_session, create_db_and_tables
+from app.models import User, Child, Transaction
+from app.crud import (
+    ensure_permissions_exist,
+    create_user,
+    create_child_for_user,
+    create_transaction,
+    recalc_interest,
+    get_transactions_by_child,
+    calculate_balance,
+    get_account_by_child,
+)
+from app.auth import get_password_hash
+from app.acl import ALL_PERMISSIONS
+
+
+async def run_interest_test(persist: bool = False) -> dict:
+    """Create backdated transactions and verify interest calculations."""
+    results: List[str] = []
+    success = True
+
+    if persist:
+        TestSession = async_session
+        await create_db_and_tables()
+    else:
+        engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+        TestSession = async_sessionmaker(engine, expire_on_commit=False)
+        async with engine.begin() as conn:
+            await conn.run_sync(SQLModel.metadata.create_all)
+
+    async with TestSession() as session:
+        await ensure_permissions_exist(session, ALL_PERMISSIONS)
+        parent = User(
+            name="Interest Parent",
+            email="interest@example.com",
+            password_hash=get_password_hash("parentpass"),
+            role="parent",
+        )
+        session.add(parent)
+        await session.commit()
+        await session.refresh(parent)
+
+        child_pos = await create_child_for_user(
+            session, Child(first_name="Saver", access_code="SAV"), parent.id
+        )
+        child_neg = await create_child_for_user(
+            session, Child(first_name="Spender", access_code="SPN"), parent.id
+        )
+
+        five_days = datetime.utcnow() - timedelta(days=5)
+
+        await create_transaction(
+            session,
+            Transaction(
+                child_id=child_pos.id,
+                type="credit",
+                amount=100,
+                memo="Initial Deposit",
+                initiated_by="parent",
+                initiator_id=parent.id,
+                timestamp=five_days,
+            ),
+        )
+        await recalc_interest(session, child_pos.id)
+        txs = await get_transactions_by_child(session, child_pos.id)
+        if any(tx.memo == "Interest" and tx.type == "credit" for tx in txs):
+            results.append("Interest applied to positive balance")
+        else:
+            results.append("Interest missing for positive balance")
+            success = False
+
+        await create_transaction(
+            session,
+            Transaction(
+                child_id=child_neg.id,
+                type="debit",
+                amount=50,
+                memo="Initial Debit",
+                initiated_by="parent",
+                initiator_id=parent.id,
+                timestamp=five_days,
+            ),
+        )
+        await recalc_interest(session, child_neg.id)
+        txs2 = await get_transactions_by_child(session, child_neg.id)
+        if any(tx.memo == "Interest" and tx.type == "debit" for tx in txs2):
+            results.append("Penalty interest applied")
+        else:
+            results.append("Penalty interest missing")
+            success = False
+
+        bal_pos = await calculate_balance(session, child_pos.id)
+        bal_neg = await calculate_balance(session, child_neg.id)
+        account_pos = await get_account_by_child(session, child_pos.id)
+        account_neg = await get_account_by_child(session, child_neg.id)
+
+        results.append(
+            f"Positive balance: {bal_pos:.2f}, interest earned: {account_pos.total_interest_earned:.2f}"
+        )
+        results.append(
+            f"Negative balance: {bal_neg:.2f}, interest earned: {account_neg.total_interest_earned:.2f}"
+        )
+
+    return {"success": success, "details": results}
+
+
+if __name__ == "__main__":
+    import asyncio
+    print(asyncio.run(run_interest_test()))

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -217,6 +217,7 @@ function App() {
     setToken(null)
     setIsChildAccount(false)
     setChildId(null)
+    setChildren([])
     setLedger(null)
     setSelectedChild(null)
     setWithdrawals([])


### PR DESCRIPTION
## Summary
- add ACL checks in integration tests
- create interest test suite exercising interest accrual and penalties
- expose `/tests/interest-test` API endpoint to run interest tests

## Testing
- `python -m app.tests.api_tests`
- `python -m app.tests.interest_tests`

------
https://chatgpt.com/codex/tasks/task_e_688ce66468c4832391140c49d8cb38e2