### PR TITLE
Add sortable paginated ledger table

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -142,6 +142,17 @@
   background-color: rgba(0, 0, 0, 0.03);
 }
 
+.sortable {
+  cursor: pointer;
+}
+
+.table-controls {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 0.5em;
+  align-items: center;
+}
+
 .dark .ledger-table th {
   background-color: rgba(255, 255, 255, 0.1);
 }

--- a/frontend/src/pages/ChildDashboard.tsx
+++ b/frontend/src/pages/ChildDashboard.tsx
@@ -79,7 +79,10 @@ export default function ChildDashboard({ token, childId, apiUrl, onLogout }: Pro
       {ledger && (
         <>
           <p>Balance: {ledger.balance.toFixed(2)}</p>
-          <LedgerTable transactions={ledger.transactions} onWidth={w => !tableWidth && setTableWidth(w)} />
+          <LedgerTable
+            transactions={ledger.transactions}
+            onWidth={w => !tableWidth && setTableWidth(w)}
+          />
         </>
       )}
       <form

--- a/frontend/src/pages/ParentDashboard.tsx
+++ b/frontend/src/pages/ParentDashboard.tsx
@@ -155,6 +155,7 @@ export default function ParentDashboard({
           <LedgerTable
             transactions={ledger.transactions}
             onWidth={(w) => !tableWidth && setTableWidth(w)}
+            allowDownload
             renderActions={(tx) => (
               <>
                 {canEdit && tx.initiated_by !== "system" && (


### PR DESCRIPTION
## Summary
- add pagination and sorting to `LedgerTable`
- enable CSV download in parent dashboard
- adjust child dashboard ledger usage
- style new table controls

## Testing
- `npm run lint`
- `npm run build`
- `pytest backend/app/tests`

------
https://chatgpt.com/codex/tasks/task_e_688d27d940088323a37666a9e567259f