### PR TITLE
Implement certificate deposit (CD) feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,15 @@ The goal is to teach kids about money through experience — without handing ove
 - Daily **compound interest**, with optional **bonus tiers** or promotions
 - Full ledger of transactions: amount, memo, date, creator, type, promo ID (optional)
 
+### 💰 Certificate Deposits
+Parents can offer time-locked certificates with a custom term and interest rate.
+Children can review these offers and choose to accept or reject them. Accepting
+debits the CD amount from the child’s balance and locks it until maturity. When
+the term ends the principal plus interest is automatically deposited. Admins may
+force a redemption early via `POST /cds/{cd_id}/redeem`; early redemptions return
+the principal and charge a 10% penalty. The `/tests/cd-issue` and
+`/tests/cd-redeem` endpoints help generate and redeem CDs for integration tests.
+
 ### 🔐 Permissions & Controls
 - Withdrawals are **requested** by the child, and **approved/denied** by guardians
 - Accounts can be **frozen** or have **limits**

--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ Parents can offer time-locked certificates with a custom term and interest rate.
 Children can review these offers and choose to accept or reject them. Accepting
 debits the CD amount from the child’s balance and locks it until maturity. When
 the term ends the principal plus interest is automatically deposited. Admins may
-force a redemption early via `POST /cds/{cd_id}/redeem`; early redemptions return
+force a redemption early via `POST /cds/{cd_id}/redeem`; children can redeem
+early themselves using `POST /cds/{cd_id}/redeem-early`. Early redemptions return
 the principal and charge a 10% penalty. The `/tests/cd-issue` and
 `/tests/cd-redeem` endpoints help generate and redeem CDs for integration tests.
 

--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -143,7 +143,7 @@ async def get_current_identity(
 
 async def get_child_by_id(db: AsyncSession, child_id: int):
     result = await db.execute(select(Child).where(Child.id == child_id))
-    return result.scalar_one_or_none()
+    return result.scalars().first()
 
 
 async def get_current_child(

--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -161,7 +161,7 @@ async def get_child_by_access_code(db: AsyncSession, access_code: str):
     result = await db.execute(
         select(Child).where(Child.access_code == access_code)
     )
-    return result.scalar_one_or_none()
+    return result.scalars().first()
 
 
 async def get_child(db: AsyncSession, child_id: int) -> Child | None:

--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -303,6 +303,7 @@ async def recalc_interest(db: AsyncSession, child_id: int) -> None:
         delete(Transaction).where(
             Transaction.child_id == child_id,
             Transaction.initiated_by == "system",
+            Transaction.memo == "Interest",
         )
     )
     await db.commit()
@@ -480,7 +481,7 @@ async def redeem_cd(
         matured = matured or datetime.utcnow() >= cd.matures_at
 
     if matured:
-        payout = cd.amount * (1 + cd.interest_rate)
+        payout = round(cd.amount * (1 + cd.interest_rate), 2)
         await create_transaction(
             db,
             Transaction(

--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -9,6 +9,7 @@ from app.models import (
     Transaction,
     WithdrawalRequest,
     Account,
+    CertificateDeposit,
     Permission,
     UserPermissionLink,
 )
@@ -18,7 +19,9 @@ from app.acl import get_default_permissions_for_role
 
 async def ensure_permissions_exist(db: AsyncSession, names: list[str]) -> None:
     for name in names:
-        result = await db.execute(select(Permission).where(Permission.name == name))
+        result = await db.execute(
+            select(Permission).where(Permission.name == name)
+        )
         perm = result.scalar_one_or_none()
         if not perm:
             db.add(Permission(name=name))
@@ -29,14 +32,18 @@ async def assign_permissions_by_names(
     db: AsyncSession, user: User, names: list[str]
 ) -> None:
     for name in names:
-        result = await db.execute(select(Permission).where(Permission.name == name))
+        result = await db.execute(
+            select(Permission).where(Permission.name == name)
+        )
         perm = result.scalar_one_or_none()
         if perm:
             exists = any(
                 link.permission_id == perm.id for link in user.permission_links
             )
             if not exists:
-                db.add(UserPermissionLink(user_id=user.id, permission_id=perm.id))
+                db.add(
+                    UserPermissionLink(user_id=user.id, permission_id=perm.id)
+                )
     await db.commit()
 
 
@@ -44,11 +51,18 @@ async def remove_permissions_by_names(
     db: AsyncSession, user: User, names: list[str]
 ) -> None:
     for name in names:
-        result = await db.execute(select(Permission).where(Permission.name == name))
+        result = await db.execute(
+            select(Permission).where(Permission.name == name)
+        )
         perm = result.scalar_one_or_none()
         if perm:
             link = next(
-                (l for l in user.permission_links if l.permission_id == perm.id), None
+                (
+                    l
+                    for l in user.permission_links
+                    if l.permission_id == perm.id
+                ),
+                None,
             )
             if link:
                 await db.delete(link)
@@ -134,13 +148,19 @@ async def create_child_for_user(db: AsyncSession, child: Child, user_id: int):
 
 
 async def get_children_by_user(db: AsyncSession, user_id: int):
-    query = select(Child).join(ChildUserLink).where(ChildUserLink.user_id == user_id)
+    query = (
+        select(Child)
+        .join(ChildUserLink)
+        .where(ChildUserLink.user_id == user_id)
+    )
     result = await db.execute(query)
     return result.scalars().all()
 
 
 async def get_child_by_access_code(db: AsyncSession, access_code: str):
-    result = await db.execute(select(Child).where(Child.access_code == access_code))
+    result = await db.execute(
+        select(Child).where(Child.access_code == access_code)
+    )
     return result.scalar_one_or_none()
 
 
@@ -180,8 +200,12 @@ async def set_child_frozen(
     return child
 
 
-async def get_account_by_child(db: AsyncSession, child_id: int) -> Account | None:
-    result = await db.execute(select(Account).where(Account.child_id == child_id))
+async def get_account_by_child(
+    db: AsyncSession, child_id: int
+) -> Account | None:
+    result = await db.execute(
+        select(Account).where(Account.child_id == child_id)
+    )
     return result.scalar_one_or_none()
 
 
@@ -219,7 +243,9 @@ async def create_transaction(db: AsyncSession, tx: Transaction) -> Transaction:
     return tx
 
 
-async def get_transaction(db: AsyncSession, transaction_id: int) -> Transaction | None:
+async def get_transaction(
+    db: AsyncSession, transaction_id: int
+) -> Transaction | None:
     result = await db.execute(
         select(Transaction).where(Transaction.id == transaction_id)
     )
@@ -250,7 +276,9 @@ async def get_transactions_by_child(
 
 
 async def get_all_transactions(db: AsyncSession) -> list[Transaction]:
-    result = await db.execute(select(Transaction).order_by(Transaction.timestamp))
+    result = await db.execute(
+        select(Transaction).order_by(Transaction.timestamp)
+    )
     return result.scalars().all()
 
 
@@ -281,7 +309,10 @@ async def recalc_interest(db: AsyncSession, child_id: int) -> None:
 
     transactions = await db.execute(
         select(Transaction)
-        .where(Transaction.child_id == child_id, Transaction.initiated_by != "system")
+        .where(
+            Transaction.child_id == child_id,
+            Transaction.initiated_by != "system",
+        )
         .order_by(Transaction.timestamp)
     )
     base_txs = list(transactions.scalars().all())
@@ -299,7 +330,9 @@ async def recalc_interest(db: AsyncSession, child_id: int) -> None:
     day = start_date
 
     while day < today:
-        while tx_idx < len(base_txs) and base_txs[tx_idx].timestamp.date() == day:
+        while (
+            tx_idx < len(base_txs) and base_txs[tx_idx].timestamp.date() == day
+        ):
             tx = base_txs[tx_idx]
             if tx.type == "credit":
                 current_balance += tx.amount
@@ -353,7 +386,8 @@ async def get_pending_withdrawals_for_parent(
         .join(Child)
         .join(ChildUserLink)
         .where(
-            ChildUserLink.user_id == parent_id, WithdrawalRequest.status == "pending"
+            ChildUserLink.user_id == parent_id,
+            WithdrawalRequest.status == "pending",
         )
         .order_by(WithdrawalRequest.requested_at)
     )
@@ -388,3 +422,75 @@ async def save_withdrawal_request(
     await db.commit()
     await db.refresh(req)
     return req
+
+
+async def create_cd(
+    db: AsyncSession, cd: CertificateDeposit
+) -> CertificateDeposit:
+    db.add(cd)
+    await db.commit()
+    await db.refresh(cd)
+    return cd
+
+
+async def get_cd(db: AsyncSession, cd_id: int) -> CertificateDeposit | None:
+    result = await db.execute(
+        select(CertificateDeposit).where(CertificateDeposit.id == cd_id)
+    )
+    return result.scalar_one_or_none()
+
+
+async def save_cd(
+    db: AsyncSession, cd: CertificateDeposit
+) -> CertificateDeposit:
+    db.add(cd)
+    await db.commit()
+    await db.refresh(cd)
+    return cd
+
+
+async def get_cds_by_child(
+    db: AsyncSession, child_id: int
+) -> list[CertificateDeposit]:
+    result = await db.execute(
+        select(CertificateDeposit)
+        .where(CertificateDeposit.child_id == child_id)
+        .order_by(CertificateDeposit.created_at)
+    )
+    return result.scalars().all()
+
+
+async def redeem_cd(
+    db: AsyncSession, cd: CertificateDeposit
+) -> CertificateDeposit:
+    from .crud import create_transaction, recalc_interest  # avoid circular
+
+    if cd.status != "accepted":
+        return cd
+    payout = cd.amount * (1 + cd.interest_rate)
+    tx = Transaction(
+        child_id=cd.child_id,
+        type="credit",
+        amount=payout,
+        memo=f"CD #{cd.id} maturity",
+        initiated_by="system",
+        initiator_id=0,
+    )
+    await create_transaction(db, tx)
+    cd.status = "redeemed"
+    cd.redeemed_at = datetime.utcnow()
+    await save_cd(db, cd)
+    await recalc_interest(db, cd.child_id)
+    return cd
+
+
+async def redeem_matured_cds(db: AsyncSession) -> None:
+    result = await db.execute(
+        select(CertificateDeposit).where(
+            CertificateDeposit.status == "accepted",
+            CertificateDeposit.matures_at <= datetime.utcnow(),
+        )
+    )
+    cds = result.scalars().all()
+    for cd in cds:
+        await redeem_cd(db, cd)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,6 +1,15 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from app.routes import users, children, auth, transactions, withdrawals, admin, tests
+from app.routes import (
+    users,
+    children,
+    auth,
+    transactions,
+    withdrawals,
+    admin,
+    tests,
+    cds,
+)
 from app.database import create_db_and_tables, async_session
 from app.crud import recalc_interest, ensure_permissions_exist
 from app.models import Child
@@ -35,6 +44,9 @@ async def daily_interest_task():
             child_ids = result.scalars().all()
             for cid in child_ids:
                 await recalc_interest(session, cid)
+            from app.crud import redeem_matured_cds
+
+            await redeem_matured_cds(session)
         await asyncio.sleep(60 * 60 * 24)
 
 
@@ -43,6 +55,7 @@ app.include_router(children.router)
 app.include_router(auth.router)
 app.include_router(transactions.router)
 app.include_router(withdrawals.router)
+app.include_router(cds.router)
 app.include_router(admin.router)
 app.include_router(tests.router)
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -41,7 +41,7 @@ class User(SQLModel, table=True):
 class Child(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
     first_name: str
-    access_code: str
+    access_code: str = Field(unique=True)
     account_frozen: bool = False
     created_at: datetime = Field(default_factory=datetime.utcnow)
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -14,7 +14,9 @@ class UserPermissionLink(SQLModel, table=True):
 class Permission(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
     name: str
-    user_links: List["UserPermissionLink"] = Relationship(back_populates="permission")
+    user_links: List["UserPermissionLink"] = Relationship(
+        back_populates="permission"
+    )
     users: List["User"] = Relationship(
         back_populates="permissions", link_model=UserPermissionLink
     )
@@ -28,7 +30,9 @@ class User(SQLModel, table=True):
     role: str  # 'viewer', 'depositor', 'withdrawer', 'admin'
 
     children: List["ChildUserLink"] = Relationship(back_populates="user")
-    permission_links: List["UserPermissionLink"] = Relationship(back_populates="user")
+    permission_links: List["UserPermissionLink"] = Relationship(
+        back_populates="user"
+    )
     permissions: List[Permission] = Relationship(
         back_populates="users", link_model=UserPermissionLink
     )
@@ -72,7 +76,9 @@ class Account(SQLModel, table=True):
 class Transaction(SQLModel, table=True):
     """Ledger transaction representing credits and debits on a child's account."""
 
-    id: Optional[int] = Field(default=None, primary_key=True, alias="transaction_id")
+    id: Optional[int] = Field(
+        default=None, primary_key=True, alias="transaction_id"
+    )
     child_id: int = Field(foreign_key="child.id")
     type: str  # "credit" or "debit"
     amount: float
@@ -97,3 +103,20 @@ class WithdrawalRequest(SQLModel, table=True):
 
     child: Child = Relationship(back_populates="withdrawal_requests")
     approver: Optional[User] = Relationship()
+
+
+class CertificateDeposit(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    child_id: int = Field(foreign_key="child.id")
+    parent_id: int = Field(foreign_key="user.id")
+    amount: float
+    interest_rate: float
+    term_days: int
+    status: str = "offered"  # offered, accepted, rejected, redeemed
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    accepted_at: Optional[datetime] = None
+    matures_at: Optional[datetime] = None
+    redeemed_at: Optional[datetime] = None
+
+    child: Child = Relationship()
+    parent: User = Relationship()

--- a/backend/app/routes/__init__.py
+++ b/backend/app/routes/__init__.py
@@ -1,4 +1,4 @@
-from . import auth, users, children, transactions, withdrawals, admin, tests
+from . import auth, users, children, transactions, withdrawals, admin, tests, cds
 
 __all__ = [
     "auth",
@@ -6,6 +6,7 @@ __all__ = [
     "children",
     "transactions",
     "withdrawals",
+    "cds",
     "admin",
     "tests",
 ]

--- a/backend/app/routes/cds.py
+++ b/backend/app/routes/cds.py
@@ -113,3 +113,18 @@ async def redeem_cd_route(
 
     cd = await redeem_cd(db, cd)
     return cd
+
+
+@router.post("/{cd_id}/redeem-early", response_model=CDRead)
+async def redeem_cd_early_route(
+    cd_id: int,
+    child: Child = Depends(get_current_child),
+    db: AsyncSession = Depends(get_session),
+):
+    cd = await _get_child_cd(db, cd_id, child.id)
+    if cd.status != "accepted":
+        raise HTTPException(status_code=400, detail="Cannot redeem")
+    from app.crud import redeem_cd
+
+    cd = await redeem_cd(db, cd)
+    return cd

--- a/backend/app/routes/cds.py
+++ b/backend/app/routes/cds.py
@@ -1,0 +1,115 @@
+from datetime import datetime, timedelta
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_session
+from app.auth import require_role, get_current_child
+from app.models import CertificateDeposit, Child, User, Transaction
+from app.schemas import CDCreate, CDRead
+from app.crud import (
+    create_cd,
+    get_cd,
+    save_cd,
+    get_cds_by_child,
+    get_children_by_user,
+    calculate_balance,
+    create_transaction,
+)
+
+router = APIRouter(prefix="/cds", tags=["cds"])
+
+
+@router.post("/", response_model=CDRead)
+async def create_cd_offer(
+    data: CDCreate,
+    db: AsyncSession = Depends(get_session),
+    current_user: User = Depends(require_role("parent", "admin")),
+):
+    if current_user.role != "admin":
+        children = await get_children_by_user(db, current_user.id)
+        if data.child_id not in [c.id for c in children]:
+            raise HTTPException(status_code=404, detail="Child not found")
+    cd = CertificateDeposit(
+        child_id=data.child_id,
+        parent_id=current_user.id,
+        amount=data.amount,
+        interest_rate=data.interest_rate,
+        term_days=data.term_days,
+    )
+    return await create_cd(db, cd)
+
+
+@router.get("/child", response_model=list[CDRead])
+async def my_cds(
+    child: Child = Depends(get_current_child),
+    db: AsyncSession = Depends(get_session),
+):
+    return await get_cds_by_child(db, child.id)
+
+
+async def _get_child_cd(
+    db: AsyncSession, cd_id: int, child_id: int
+) -> CertificateDeposit:
+    cd = await get_cd(db, cd_id)
+    if not cd or cd.child_id != child_id:
+        raise HTTPException(status_code=404, detail="CD not found")
+    return cd
+
+
+@router.post("/{cd_id}/accept", response_model=CDRead)
+async def accept_cd(
+    cd_id: int,
+    child: Child = Depends(get_current_child),
+    db: AsyncSession = Depends(get_session),
+):
+    cd = await _get_child_cd(db, cd_id, child.id)
+    if cd.status != "offered":
+        raise HTTPException(status_code=400, detail="Cannot accept")
+    balance = await calculate_balance(db, child.id)
+    if balance < cd.amount:
+        raise HTTPException(status_code=400, detail="Insufficient funds")
+    await create_transaction(
+        db,
+        Transaction(
+            child_id=child.id,
+            type="debit",
+            amount=cd.amount,
+            memo=f"CD #{cd.id} purchase",
+            initiated_by="child",
+            initiator_id=child.id,
+        ),
+    )
+    cd.status = "accepted"
+    cd.accepted_at = datetime.utcnow()
+    cd.matures_at = cd.accepted_at + timedelta(days=cd.term_days)
+    await save_cd(db, cd)
+    return cd
+
+
+@router.post("/{cd_id}/reject", response_model=CDRead)
+async def reject_cd(
+    cd_id: int,
+    child: Child = Depends(get_current_child),
+    db: AsyncSession = Depends(get_session),
+):
+    cd = await _get_child_cd(db, cd_id, child.id)
+    if cd.status != "offered":
+        raise HTTPException(status_code=400, detail="Cannot reject")
+    cd.status = "rejected"
+    await save_cd(db, cd)
+    return cd
+
+
+@router.post("/{cd_id}/redeem", response_model=CDRead)
+async def redeem_cd_route(
+    cd_id: int,
+    db: AsyncSession = Depends(get_session),
+    current_user: User = Depends(require_role("admin")),
+):
+    cd = await get_cd(db, cd_id)
+    if not cd:
+        raise HTTPException(status_code=404, detail="CD not found")
+    from app.crud import redeem_cd
+
+    cd = await redeem_cd(db, cd)
+    return cd

--- a/backend/app/routes/tests.py
+++ b/backend/app/routes/tests.py
@@ -1,6 +1,9 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
+from app.models import User
+from app.auth import require_role
 
 router = APIRouter(prefix="/tests", tags=["tests"])
+
 
 @router.post("/run")
 async def run_tests_route(persist: bool = False):
@@ -21,3 +24,25 @@ async def interest_test_route(persist: bool = False, days: int = 5):
     from app.tests.interest_tests import run_interest_test
 
     return await run_interest_test(persist=persist, days=days)
+
+
+@router.post("/cd-issue")
+async def cd_issue_route(
+    persist: bool = False, days: int = 30, rate: float = 0.05
+):
+    """Create test users and issue a CD."""
+    from app.tests.cd_tests import run_cd_issue_test
+
+    return await run_cd_issue_test(persist=persist, days=days, rate=rate)
+
+
+@router.post("/cd-redeem")
+async def cd_redeem_route(
+    cd_id: int,
+    persist: bool = False,
+    current_user: User = Depends(require_role("admin")),
+):
+    """Redeem a CD as if matured today. Admin only."""
+    from app.tests.cd_tests import run_cd_redeem_test
+
+    return await run_cd_redeem_test(cd_id=cd_id, persist=persist)

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -19,6 +19,7 @@ from .withdrawal import (
     DenyRequest,
 )
 from .permission import PermissionRead, PermissionsUpdate
+from .cd import CDCreate, CDRead
 
 __all__ = [
     "UserCreate",
@@ -40,4 +41,6 @@ __all__ = [
     "DenyRequest",
     "PermissionRead",
     "PermissionsUpdate",
+    "CDCreate",
+    "CDRead",
 ]

--- a/backend/app/schemas/cd.py
+++ b/backend/app/schemas/cd.py
@@ -1,0 +1,27 @@
+from pydantic import BaseModel, Field
+from typing import Optional
+from datetime import datetime
+
+
+class CDCreate(BaseModel):
+    child_id: int
+    amount: float
+    interest_rate: float
+    term_days: int
+
+
+class CDRead(BaseModel):
+    id: int
+    child_id: int
+    parent_id: int
+    amount: float
+    interest_rate: float
+    term_days: int
+    status: str
+    created_at: datetime
+    accepted_at: Optional[datetime] = None
+    matures_at: Optional[datetime] = None
+    redeemed_at: Optional[datetime] = None
+
+    class Config:
+        model_config = {"from_attributes": True}

--- a/backend/app/tests/cd_tests.py
+++ b/backend/app/tests/cd_tests.py
@@ -1,0 +1,111 @@
+from datetime import datetime, timedelta
+from sqlalchemy.ext.asyncio import (
+    create_async_engine,
+    async_sessionmaker,
+    AsyncSession,
+)
+from sqlmodel import SQLModel, select
+
+from app.database import async_session, create_db_and_tables
+from app.models import (
+    User,
+    Child,
+    CertificateDeposit,
+    Permission,
+    UserPermissionLink,
+)
+from app.crud import (
+    ensure_permissions_exist,
+    create_child_for_user,
+    create_transaction,
+    recalc_interest,
+    create_cd,
+    redeem_cd,
+)
+from app.auth import get_password_hash
+from app.acl import ALL_PERMISSIONS, ROLE_DEFAULT_PERMISSIONS
+from app.models import Transaction
+
+
+async def run_cd_issue_test(
+    persist: bool = False, days: int = 30, rate: float = 0.05
+) -> dict:
+    results = []
+    if persist:
+        TestSession = async_session
+        await create_db_and_tables()
+    else:
+        engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+        TestSession = async_sessionmaker(engine, expire_on_commit=False)
+        async with engine.begin() as conn:
+            await conn.run_sync(SQLModel.metadata.create_all)
+
+    async with TestSession() as session:
+        await ensure_permissions_exist(session, ALL_PERMISSIONS)
+        parent = User(
+            name="CD Parent",
+            email="cdparent@example.com",
+            password_hash=get_password_hash("parentpass"),
+            role="parent",
+        )
+        session.add(parent)
+        await session.commit()
+        await session.refresh(parent)
+        for perm_name in ROLE_DEFAULT_PERMISSIONS["parent"]:
+            result = await session.execute(
+                select(Permission).where(Permission.name == perm_name)
+            )
+            perm = result.scalar_one()
+            session.add(
+                UserPermissionLink(user_id=parent.id, permission_id=perm.id)
+            )
+        await session.commit()
+
+        child = await create_child_for_user(
+            session, Child(first_name="CDKid", access_code="CDK"), parent.id
+        )
+
+        await create_transaction(
+            session,
+            Transaction(
+                child_id=child.id,
+                type="credit",
+                amount=100,
+                memo="Initial",
+                initiated_by="parent",
+                initiator_id=parent.id,
+            ),
+        )
+        await recalc_interest(session, child.id)
+
+        cd = await create_cd(
+            session,
+            CertificateDeposit(
+                child_id=child.id,
+                parent_id=parent.id,
+                amount=50,
+                interest_rate=rate,
+                term_days=days,
+            ),
+        )
+
+    return {"success": True, "cd_id": cd.id}
+
+
+async def run_cd_redeem_test(cd_id: int, persist: bool = False) -> dict:
+    if persist:
+        TestSession = async_session
+        await create_db_and_tables()
+    else:
+        engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+        TestSession = async_sessionmaker(engine, expire_on_commit=False)
+        async with engine.begin() as conn:
+            await conn.run_sync(SQLModel.metadata.create_all)
+
+    async with TestSession() as session:
+        cd = await session.get(CertificateDeposit, cd_id)
+        if not cd:
+            return {"success": False, "error": "CD not found"}
+        await redeem_cd(session, cd)
+
+    return {"success": True}

--- a/frontend/src/pages/ChildDashboard.tsx
+++ b/frontend/src/pages/ChildDashboard.tsx
@@ -98,10 +98,17 @@ export default function ChildDashboard({ token, childId, apiUrl, onLogout }: Pro
         <div>
           <h4>CD Offers</h4>
           <ul className="list">
-            {cds.map(cd => (
-              <li key={cd.id}>
-                {cd.amount} for {cd.term_days} days at {(cd.interest_rate * 100).toFixed(2)}% - {cd.status}
-                {cd.status === 'offered' && (
+            {cds.map(cd => {
+              const daysLeft = cd.matures_at
+                ? Math.ceil((new Date(cd.matures_at).getTime() - Date.now()) / 86400000)
+                : null
+              return (
+                <li key={cd.id}>
+                  {cd.amount} for {cd.term_days} days at {(cd.interest_rate * 100).toFixed(2)}% - {cd.status}
+                  {cd.status === 'accepted' && daysLeft !== null && (
+                    <span> (redeems in {daysLeft} days)</span>
+                  )}
+                  {cd.status === 'offered' && (
                   <>
                     <button
                       onClick={async () => {
@@ -130,8 +137,9 @@ export default function ChildDashboard({ token, childId, apiUrl, onLogout }: Pro
                     </button>
                   </>
                 )}
-              </li>
-            ))}
+                </li>
+              )
+            })}
           </ul>
         </div>
       )}

--- a/frontend/src/pages/ChildDashboard.tsx
+++ b/frontend/src/pages/ChildDashboard.tsx
@@ -108,6 +108,27 @@ export default function ChildDashboard({ token, childId, apiUrl, onLogout }: Pro
                   {cd.status === 'accepted' && daysLeft !== null && (
                     <span> (redeems in {daysLeft} days)</span>
                   )}
+                  {cd.status === 'accepted' && daysLeft !== null && daysLeft > 0 && (
+                    <button
+                      onClick={async () => {
+                        if (
+                          !confirm(
+                            'Redeem this CD early? A 10% penalty will be charged.'
+                          )
+                        )
+                          return
+                        await fetch(`${apiUrl}/cds/${cd.id}/redeem-early`, {
+                          method: 'POST',
+                          headers: { Authorization: `Bearer ${token}` },
+                        })
+                        fetchCds()
+                        fetchLedger()
+                      }}
+                      className="ml-05"
+                    >
+                      Redeem Early
+                    </button>
+                  )}
                   {cd.status === 'offered' && (
                     <>
                       <button

--- a/frontend/src/pages/ChildDashboard.tsx
+++ b/frontend/src/pages/ChildDashboard.tsx
@@ -109,34 +109,34 @@ export default function ChildDashboard({ token, childId, apiUrl, onLogout }: Pro
                     <span> (redeems in {daysLeft} days)</span>
                   )}
                   {cd.status === 'offered' && (
-                  <>
-                    <button
-                      onClick={async () => {
-                        await fetch(`${apiUrl}/cds/${cd.id}/accept`, {
-                          method: 'POST',
-                          headers: { Authorization: `Bearer ${token}` },
-                        })
-                        fetchCds()
-                        fetchLedger()
-                      }}
-                      className="ml-1"
-                    >
-                      Accept
-                    </button>
-                    <button
-                      onClick={async () => {
-                        await fetch(`${apiUrl}/cds/${cd.id}/reject`, {
-                          method: 'POST',
-                          headers: { Authorization: `Bearer ${token}` },
-                        })
-                        fetchCds()
-                      }}
-                      className="ml-05"
-                    >
-                      Reject
-                    </button>
-                  </>
-                )}
+                    <>
+                      <button
+                        onClick={async () => {
+                          await fetch(`${apiUrl}/cds/${cd.id}/accept`, {
+                            method: 'POST',
+                            headers: { Authorization: `Bearer ${token}` },
+                          })
+                          fetchCds()
+                          fetchLedger()
+                        }}
+                        className="ml-1"
+                      >
+                        Accept
+                      </button>
+                      <button
+                        onClick={async () => {
+                          await fetch(`${apiUrl}/cds/${cd.id}/reject`, {
+                            method: 'POST',
+                            headers: { Authorization: `Bearer ${token}` },
+                          })
+                          fetchCds()
+                        }}
+                        className="ml-05"
+                      >
+                        Reject
+                      </button>
+                    </>
+                  )}
                 </li>
               )
             })}

--- a/frontend/src/pages/ParentDashboard.tsx
+++ b/frontend/src/pages/ParentDashboard.tsx
@@ -63,6 +63,9 @@ export default function ParentDashboard({
   const [accessCode, setAccessCode] = useState("");
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [tableWidth, setTableWidth] = useState<number>();
+  const [cdAmount, setCdAmount] = useState("");
+  const [cdRate, setCdRate] = useState("");
+  const [cdDays, setCdDays] = useState("");
   const canEdit = permissions.includes("edit_transaction");
   const canDelete = permissions.includes("delete_transaction");
 
@@ -260,10 +263,58 @@ export default function ParentDashboard({
               value={txMemo}
               onChange={(e) => setTxMemo(e.target.value)}
             />
-            <button type="submit">Add</button>
-          </form>
-        </div>
-      )}
+          <button type="submit">Add</button>
+        </form>
+        <form
+          onSubmit={async (e) => {
+            e.preventDefault();
+            await fetch(`${apiUrl}/cds`, {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/json",
+                Authorization: `Bearer ${token}`,
+              },
+              body: JSON.stringify({
+                child_id: selectedChild,
+                amount: Number(cdAmount),
+                interest_rate: Number(cdRate),
+                term_days: Number(cdDays),
+              }),
+            });
+            setCdAmount("");
+            setCdRate("");
+            setCdDays("");
+          }}
+          className="form"
+        >
+          <h4>Offer CD</h4>
+          <input
+            type="number"
+            step="0.01"
+            placeholder="Amount"
+            value={cdAmount}
+            onChange={(e) => setCdAmount(e.target.value)}
+            required
+          />
+          <input
+            type="number"
+            step="0.0001"
+            placeholder="Rate"
+            value={cdRate}
+            onChange={(e) => setCdRate(e.target.value)}
+            required
+          />
+          <input
+            type="number"
+            placeholder="Days"
+            value={cdDays}
+            onChange={(e) => setCdDays(e.target.value)}
+            required
+          />
+          <button type="submit">Send</button>
+        </form>
+      </div>
+    )}
       {pendingWithdrawals.length > 0 && (
         <div>
           <h4>Pending Withdrawal Requests</h4>


### PR DESCRIPTION
## Summary
- add CertificateDeposit model
- CRUD helpers for CDs and daily maturity redemption
- API router for CD creation and acceptance
- testing endpoints for issuing and redeeming CDs
- frontend forms for parents to offer CDs and children to accept/reject

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d2b97a864832385f8809b74314f25