### PR TITLE
Add interest rate management and site settings

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -23,6 +23,7 @@ async def create_db_and_tables() -> None:
         WithdrawalRequest,
         Permission,
         UserPermissionLink,
+        Settings,
     )
 
     async with engine.begin() as conn:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,6 +9,7 @@ from app.routes import (
     admin,
     tests,
     cds,
+    settings,
 )
 from app.database import create_db_and_tables, async_session
 from app.crud import recalc_interest, ensure_permissions_exist
@@ -58,8 +59,14 @@ app.include_router(withdrawals.router)
 app.include_router(cds.router)
 app.include_router(admin.router)
 app.include_router(tests.router)
+app.include_router(settings.router)
 
 
 @app.get("/")
-def read_root():
-    return {"message": "Welcome to Uncle Jon's Bank API"}
+async def read_root():
+    from app.crud import get_settings
+
+    async with async_session() as session:
+        s = await get_settings(session)
+        name = s.site_name
+    return {"message": f"Welcome to {name} API"}

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -67,6 +67,7 @@ class Account(SQLModel, table=True):
     balance: float = 0.0
     interest_rate: float = 0.01  # Daily rate for positive balances
     penalty_interest_rate: float = 0.02  # Daily rate applied when balance < 0
+    cd_penalty_rate: float = 0.1  # Penalty for early CD withdrawal
     last_interest_applied: Optional[date] = None
     total_interest_earned: float = 0.0
 
@@ -120,3 +121,11 @@ class CertificateDeposit(SQLModel, table=True):
 
     child: Child = Relationship()
     parent: User = Relationship()
+
+
+class Settings(SQLModel, table=True):
+    id: Optional[int] = Field(default=1, primary_key=True)
+    site_name: str = "Uncle Jon's Bank"
+    default_interest_rate: float = 0.01
+    default_penalty_interest_rate: float = 0.02
+    default_cd_penalty_rate: float = 0.1

--- a/backend/app/routes/__init__.py
+++ b/backend/app/routes/__init__.py
@@ -1,4 +1,4 @@
-from . import auth, users, children, transactions, withdrawals, admin, tests, cds
+from . import auth, users, children, transactions, withdrawals, admin, tests, cds, settings
 
 __all__ = [
     "auth",
@@ -7,6 +7,7 @@ __all__ = [
     "transactions",
     "withdrawals",
     "cds",
+    "settings",
     "admin",
     "tests",
 ]

--- a/backend/app/routes/admin.py
+++ b/backend/app/routes/admin.py
@@ -149,6 +149,8 @@ async def admin_list_children(
                 first_name=c.first_name,
                 account_frozen=c.account_frozen,
                 interest_rate=account.interest_rate if account else None,
+                penalty_interest_rate=account.penalty_interest_rate if account else None,
+                cd_penalty_rate=account.cd_penalty_rate if account else None,
                 total_interest_earned=(
                     account.total_interest_earned if account else None
                 ),
@@ -172,6 +174,8 @@ async def admin_get_child(
         first_name=child.first_name,
         account_frozen=child.account_frozen,
         interest_rate=account.interest_rate if account else None,
+        penalty_interest_rate=account.penalty_interest_rate if account else None,
+        cd_penalty_rate=account.cd_penalty_rate if account else None,
         total_interest_earned=account.total_interest_earned if account else None,
     )
 
@@ -198,6 +202,8 @@ async def admin_update_child(
         first_name=updated.first_name,
         account_frozen=updated.account_frozen,
         interest_rate=account.interest_rate if account else None,
+        penalty_interest_rate=account.penalty_interest_rate if account else None,
+        cd_penalty_rate=account.cd_penalty_rate if account else None,
         total_interest_earned=account.total_interest_earned if account else None,
     )
 

--- a/backend/app/routes/settings.py
+++ b/backend/app/routes/settings.py
@@ -1,0 +1,39 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_session
+from app.models import User
+from app.auth import require_role
+from app.schemas import SettingsRead, SettingsUpdate
+from app.crud import get_settings, save_settings
+
+router = APIRouter(prefix="/settings", tags=["settings"])
+
+
+@router.get("/", response_model=SettingsRead)
+async def read_settings(db: AsyncSession = Depends(get_session)):
+    settings = await get_settings(db)
+    return SettingsRead(
+        site_name=settings.site_name,
+        default_interest_rate=settings.default_interest_rate,
+        default_penalty_interest_rate=settings.default_penalty_interest_rate,
+        default_cd_penalty_rate=settings.default_cd_penalty_rate,
+    )
+
+
+@router.put("/", response_model=SettingsRead)
+async def update_settings(
+    data: SettingsUpdate,
+    db: AsyncSession = Depends(get_session),
+    current_user: User = Depends(require_role("admin")),
+):
+    settings = await get_settings(db)
+    for field, value in data.model_dump(exclude_unset=True).items():
+        setattr(settings, field, value)
+    updated = await save_settings(db, settings)
+    return SettingsRead(
+        site_name=updated.site_name,
+        default_interest_rate=updated.default_interest_rate,
+        default_penalty_interest_rate=updated.default_penalty_interest_rate,
+        default_cd_penalty_rate=updated.default_cd_penalty_rate,
+    )

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -5,6 +5,7 @@ from .child import (
     ChildLogin,
     InterestRateUpdate,
     PenaltyRateUpdate,
+    CDPenaltyRateUpdate,
     ChildUpdate,
 )
 from .transaction import (
@@ -20,6 +21,7 @@ from .withdrawal import (
 )
 from .permission import PermissionRead, PermissionsUpdate
 from .cd import CDCreate, CDRead
+from .settings import SettingsRead, SettingsUpdate
 
 __all__ = [
     "UserCreate",
@@ -32,6 +34,7 @@ __all__ = [
     "ChildLogin",
     "InterestRateUpdate",
     "PenaltyRateUpdate",
+    "CDPenaltyRateUpdate",
     "TransactionCreate",
     "TransactionRead",
     "TransactionUpdate",
@@ -43,4 +46,6 @@ __all__ = [
     "PermissionsUpdate",
     "CDCreate",
     "CDRead",
+    "SettingsRead",
+    "SettingsUpdate",
 ]

--- a/backend/app/schemas/child.py
+++ b/backend/app/schemas/child.py
@@ -14,6 +14,7 @@ class ChildRead(BaseModel):
     frozen: bool = Field(alias="account_frozen")
     interest_rate: float | None = None
     penalty_interest_rate: float | None = None
+    cd_penalty_rate: float | None = None
     total_interest_earned: float | None = None
 
     class Config:
@@ -30,6 +31,10 @@ class InterestRateUpdate(BaseModel):
 
 class PenaltyRateUpdate(BaseModel):
     penalty_interest_rate: float
+
+
+class CDPenaltyRateUpdate(BaseModel):
+    cd_penalty_rate: float
 
 
 class ChildUpdate(BaseModel):

--- a/backend/app/schemas/settings.py
+++ b/backend/app/schemas/settings.py
@@ -1,0 +1,15 @@
+from pydantic import BaseModel
+
+
+class SettingsRead(BaseModel):
+    site_name: str
+    default_interest_rate: float
+    default_penalty_interest_rate: float
+    default_cd_penalty_rate: float
+
+
+class SettingsUpdate(BaseModel):
+    site_name: str | None = None
+    default_interest_rate: float | None = None
+    default_penalty_interest_rate: float | None = None
+    default_cd_penalty_rate: float | None = None

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -5,19 +5,23 @@ interface Props {
   onLogout: () => void
   isAdmin: boolean
   isChild: boolean
+  siteName: string
 }
 
-export default function Header({ onLogout, isAdmin, isChild }: Props) {
+export default function Header({ onLogout, isAdmin, isChild, siteName }: Props) {
   return (
     <header className="header">
-      <img src="/unclejon.jpg" alt="Uncle Jon's Bank Logo" className="logo" />
+      <img src="/unclejon.jpg" alt={`${siteName} Logo`} className="logo" />
       <nav>
         <ul>
           {isChild ? (
-            <li><Link to="/child">Ledger</Link></li>
-          ) : (
-            <li><Link to="/">Dashboard</Link></li>
-          )}
+              <>
+                <li><Link to="/child">Ledger</Link></li>
+                <li><Link to="/child/profile">Profile</Link></li>
+              </>
+            ) : (
+              <li><Link to="/">Dashboard</Link></li>
+            )}
           {isAdmin && <li><Link to="/admin">Admin</Link></li>}
           <li><button onClick={onLogout}>Logout</button></li>
         </ul>

--- a/frontend/src/pages/ChildProfile.tsx
+++ b/frontend/src/pages/ChildProfile.tsx
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react'
+
+interface Props {
+  token: string
+  apiUrl: string
+}
+
+export default function ChildProfile({ token, apiUrl }: Props) {
+  const [data, setData] = useState<any>(null)
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const resp = await fetch(`${apiUrl}/children/me`, { headers: { Authorization: `Bearer ${token}` } })
+      if (resp.ok) setData(await resp.json())
+    }
+    fetchData()
+  }, [token, apiUrl])
+
+  if (!data) return <p>Loading...</p>
+
+  return (
+    <div className="container">
+      <h2>Your Profile</h2>
+      <p>Interest rate: {data.interest_rate}</p>
+      <p>Penalty rate: {data.penalty_interest_rate}</p>
+      <p>CD penalty rate: {data.cd_penalty_rate}</p>
+    </div>
+  )
+}

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -2,9 +2,10 @@ import { useState } from 'react'
 
 interface Props {
   onLogin: (token: string, isChild: boolean) => void
+  siteName: string
 }
 
-export default function LoginPage({ onLogin }: Props) {
+export default function LoginPage({ onLogin, siteName }: Props) {
   const [isChild, setIsChild] = useState(false)
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
@@ -41,7 +42,7 @@ export default function LoginPage({ onLogin }: Props) {
 
   return (
     <div className="container">
-      <center><img src="/unclejon.jpg" alt="Uncle Jon's Bank Logo" className="logo" /></center>
+      <center><img src="/unclejon.jpg" alt={siteName + ' Logo'} className="logo" /></center>
       <h2>Login</h2>
       <button onClick={() => setIsChild(!isChild)} className="mb-1">
         {isChild ? 'Switch to Parent Login' : 'Switch to Child Login'}


### PR DESCRIPTION
## Summary
- support per-child interest, penalty and CD penalty rates
- expose global Settings table with site name and default rates
- allow parents to edit their child's rates
- show rates on child profile page
- admin can manage site settings
- update frontend with dynamic site name

## Testing
- `PYTHONPATH=backend python backend/app/tests/api_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_688d3e293fa0832395ec64662611c565