### PR TITLE
feat: edit transactions via modal

### DIFF
--- a/frontend/src/components/EditTransactionModal.tsx
+++ b/frontend/src/components/EditTransactionModal.tsx
@@ -1,0 +1,124 @@
+import { useState } from "react";
+import type { Transaction } from "./LedgerTable";
+
+interface Props {
+  transaction: Transaction;
+  token: string;
+  apiUrl: string;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+export default function EditTransactionModal({
+  transaction,
+  token,
+  apiUrl,
+  onClose,
+  onSuccess,
+}: Props) {
+  const [amount, setAmount] = useState(String(transaction.amount));
+  const [memo, setMemo] = useState(transaction.memo || "");
+  const [type, setType] = useState(transaction.type);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    const amt = Number(amount);
+    if (!amount || isNaN(amt) || amt <= 0) {
+      setError("Amount must be a positive number");
+      return;
+    }
+    if (type !== "credit" && type !== "debit") {
+      setError("Type must be credit or debit");
+      return;
+    }
+    setLoading(true);
+    try {
+      const resp = await fetch(`${apiUrl}/transactions/${transaction.id}`, {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({
+          amount: amt,
+          memo: memo || null,
+          type,
+        }),
+      });
+      if (resp.ok) {
+        onSuccess();
+        onClose();
+      } else {
+        const data = await resp.json().catch(() => null);
+        setError(data?.message || "Failed to update transaction");
+      }
+    } catch (err) {
+      console.error(err);
+      setError("Failed to update transaction");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div
+      style={{
+        position: "fixed",
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        backgroundColor: "rgba(0,0,0,0.3)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+    >
+      <form
+        onSubmit={handleSubmit}
+        style={{
+          background: "white",
+          padding: "1rem",
+          borderRadius: "4px",
+          minWidth: "300px",
+        }}
+      >
+        <h4>Edit Transaction</h4>
+        {error && <p className="error">{error}</p>}
+        <input
+          type="number"
+          step="0.01"
+          placeholder="Amount"
+          value={amount}
+          onChange={(e) => setAmount(e.target.value)}
+          required
+        />
+        <input
+          placeholder="Memo"
+          value={memo}
+          onChange={(e) => setMemo(e.target.value)}
+        />
+        <select value={type} onChange={(e) => setType(e.target.value)}>
+          <option value="credit">credit</option>
+          <option value="debit">debit</option>
+        </select>
+        <div style={{ marginTop: "0.5rem" }}>
+          <button type="submit" disabled={loading}>
+            Save
+          </button>
+          <button
+            type="button"
+            onClick={onClose}
+            className="ml-05"
+            disabled={loading}
+          >
+            Cancel
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `EditTransactionModal` with amount, memo and type fields
- replace prompt-based transaction edit in parent dashboard
- refresh ledger after successful update and show API errors

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Unexpected any in other files)
- `npx eslint src/pages/ParentDashboard.tsx src/components/EditTransactionModal.tsx`


------
https://chatgpt.com/codex/tasks/task_e_688d744c88a08323a6f8855acea2ce5b