### PR TITLE
feat: add notifications to parent dashboard actions

### DIFF
--- a/frontend/src/hooks/useNotify.tsx
+++ b/frontend/src/hooks/useNotify.tsx
@@ -1,0 +1,50 @@
+import { createContext, useContext, useState, ReactNode } from "react";
+
+type NotifyType = "success" | "error";
+
+interface NotifyContextType {
+  notify: (msg: string, type?: NotifyType) => void;
+}
+
+const NotifyContext = createContext<NotifyContextType | undefined>(undefined);
+
+export function NotifyProvider({ children }: { children: ReactNode }) {
+  const [message, setMessage] = useState<string | null>(null);
+  const [type, setType] = useState<NotifyType>("success");
+
+  const notify = (msg: string, t: NotifyType = "success") => {
+    setType(t);
+    setMessage(msg);
+    setTimeout(() => setMessage(null), 3000);
+  };
+
+  return (
+    <NotifyContext.Provider value={{ notify }}>
+      {message && (
+        <div
+          className={`toast ${type}`}
+          style={{
+            position: "fixed",
+            top: "1rem",
+            right: "1rem",
+            background: type === "success" ? "#4caf50" : "#f44336",
+            color: "white",
+            padding: "0.5rem 1rem",
+            borderRadius: "4px",
+            zIndex: 1000,
+          }}
+        >
+          {message}
+        </div>
+      )}
+      {children}
+    </NotifyContext.Provider>
+  );
+}
+// eslint-disable-next-line react-refresh/only-export-components
+export function useNotify() {
+  const ctx = useContext(NotifyContext);
+  if (!ctx) throw new Error("useNotify must be used within a NotifyProvider");
+  return ctx.notify;
+}
+


### PR DESCRIPTION
## Summary
- add `useNotify` hook and provider for toast messages
- show success/error notifications and loading states for freeze, rate edits, transactions, CDs, and withdrawals

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_688d746219dc83238defa4fa8290d65c