### PR TITLE
Add fees module and promotions

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,6 +1,7 @@
 import os
 import logging
 from sqlmodel import SQLModel
+from sqlalchemy import text
 from sqlalchemy.ext.asyncio import (
     create_async_engine,
     AsyncSession,
@@ -37,6 +38,66 @@ async def create_db_and_tables() -> None:
 
     async with engine.begin() as conn:
         await conn.run_sync(SQLModel.metadata.create_all)
+
+        # --- simple schema migration for existing installs ---
+        # add new fee-related columns if they don't exist yet
+        pragma = "PRAGMA table_info('{table}')"
+        async def has_column(table: str, column: str) -> bool:
+            result = await conn.execute(text(pragma.format(table=table)))
+            cols = [row[1] for row in result.fetchall()]
+            return column in cols
+
+        # Settings table columns
+        if not await has_column("settings", "service_fee_amount"):
+            await conn.execute(
+                text(
+                    "ALTER TABLE settings ADD COLUMN service_fee_amount FLOAT DEFAULT 0"
+                )
+            )
+        if not await has_column("settings", "service_fee_is_percentage"):
+            await conn.execute(
+                text(
+                    "ALTER TABLE settings ADD COLUMN service_fee_is_percentage BOOLEAN DEFAULT 0"
+                )
+            )
+        if not await has_column("settings", "overdraft_fee_amount"):
+            await conn.execute(
+                text(
+                    "ALTER TABLE settings ADD COLUMN overdraft_fee_amount FLOAT DEFAULT 0"
+                )
+            )
+        if not await has_column("settings", "overdraft_fee_is_percentage"):
+            await conn.execute(
+                text(
+                    "ALTER TABLE settings ADD COLUMN overdraft_fee_is_percentage BOOLEAN DEFAULT 0"
+                )
+            )
+        if not await has_column("settings", "overdraft_fee_daily"):
+            await conn.execute(
+                text(
+                    "ALTER TABLE settings ADD COLUMN overdraft_fee_daily BOOLEAN DEFAULT 0"
+                )
+            )
+
+        # Account table columns
+        if not await has_column("account", "service_fee_last_charged"):
+            await conn.execute(
+                text(
+                    "ALTER TABLE account ADD COLUMN service_fee_last_charged DATE"
+                )
+            )
+        if not await has_column("account", "overdraft_fee_last_charged"):
+            await conn.execute(
+                text(
+                    "ALTER TABLE account ADD COLUMN overdraft_fee_last_charged DATE"
+                )
+            )
+        if not await has_column("account", "overdraft_fee_charged"):
+            await conn.execute(
+                text(
+                    "ALTER TABLE account ADD COLUMN overdraft_fee_charged BOOLEAN DEFAULT 0"
+                )
+            )
 
 
 async def get_session() -> AsyncSession:

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -70,6 +70,9 @@ class Account(SQLModel, table=True):
     cd_penalty_rate: float = 0.1  # Penalty for early CD withdrawal
     last_interest_applied: Optional[date] = None
     total_interest_earned: float = 0.0
+    service_fee_last_charged: Optional[date] = None
+    overdraft_fee_last_charged: Optional[date] = None
+    overdraft_fee_charged: bool = False
 
     child: Child = Relationship(back_populates="account")
 
@@ -141,3 +144,8 @@ class Settings(SQLModel, table=True):
     default_interest_rate: float = 0.01
     default_penalty_interest_rate: float = 0.02
     default_cd_penalty_rate: float = 0.1
+    service_fee_amount: float = 0.0
+    service_fee_is_percentage: bool = False
+    overdraft_fee_amount: float = 0.0
+    overdraft_fee_is_percentage: bool = False
+    overdraft_fee_daily: bool = False

--- a/backend/app/routes/admin.py
+++ b/backend/app/routes/admin.py
@@ -13,6 +13,7 @@ from app.schemas import (
     TransactionUpdate,
     PermissionRead,
     PermissionsUpdate,
+    Promotion,
 )
 from app.crud import (
     get_all_users,
@@ -31,6 +32,7 @@ from app.crud import (
     get_all_permissions,
     assign_permissions_by_names,
     remove_permissions_by_names,
+    apply_promotion,
 )
 
 router = APIRouter(prefix="/admin", tags=["admin"])
@@ -266,3 +268,15 @@ async def admin_delete_transaction(
     if not tx:
         raise HTTPException(status_code=404, detail="Transaction not found")
     await delete_transaction(db, tx)
+
+
+@router.post("/promotions")
+async def run_promotion(
+    promo: Promotion,
+    db: AsyncSession = Depends(get_session),
+    current_user: User = Depends(require_role("admin")),
+):
+    count = await apply_promotion(
+        db, promo.amount, promo.is_percentage, promo.credit, promo.memo
+    )
+    return {"accounts_updated": count}

--- a/backend/app/routes/cds.py
+++ b/backend/app/routes/cds.py
@@ -14,6 +14,7 @@ from app.crud import (
     get_children_by_user,
     calculate_balance,
     create_transaction,
+    post_transaction_update,
 )
 
 router = APIRouter(prefix="/cds", tags=["cds"])
@@ -79,6 +80,7 @@ async def accept_cd(
             initiator_id=child.id,
         ),
     )
+    await post_transaction_update(db, child.id)
     cd.status = "accepted"
     cd.accepted_at = datetime.utcnow()
     cd.matures_at = cd.accepted_at + timedelta(days=cd.term_days)

--- a/backend/app/routes/settings.py
+++ b/backend/app/routes/settings.py
@@ -18,6 +18,11 @@ async def read_settings(db: AsyncSession = Depends(get_session)):
         default_interest_rate=settings.default_interest_rate,
         default_penalty_interest_rate=settings.default_penalty_interest_rate,
         default_cd_penalty_rate=settings.default_cd_penalty_rate,
+        service_fee_amount=settings.service_fee_amount,
+        service_fee_is_percentage=settings.service_fee_is_percentage,
+        overdraft_fee_amount=settings.overdraft_fee_amount,
+        overdraft_fee_is_percentage=settings.overdraft_fee_is_percentage,
+        overdraft_fee_daily=settings.overdraft_fee_daily,
     )
 
 
@@ -36,4 +41,9 @@ async def update_settings(
         default_interest_rate=updated.default_interest_rate,
         default_penalty_interest_rate=updated.default_penalty_interest_rate,
         default_cd_penalty_rate=updated.default_cd_penalty_rate,
+        service_fee_amount=updated.service_fee_amount,
+        service_fee_is_percentage=updated.service_fee_is_percentage,
+        overdraft_fee_amount=updated.overdraft_fee_amount,
+        overdraft_fee_is_percentage=updated.overdraft_fee_is_percentage,
+        overdraft_fee_daily=updated.overdraft_fee_daily,
     )

--- a/backend/app/routes/transactions.py
+++ b/backend/app/routes/transactions.py
@@ -18,7 +18,7 @@ from app.crud import (
     get_transaction,
     save_transaction,
     delete_transaction,
-    recalc_interest,
+    post_transaction_update,
 )
 from app.auth import require_permissions, get_current_user, get_current_identity
 from app.acl import (
@@ -75,7 +75,7 @@ async def add_transaction(
         transaction.child_id,
         current_user.id,
     )
-    await recalc_interest(db, transaction.child_id)
+    await post_transaction_update(db, transaction.child_id)
     return new_tx
 
 
@@ -93,7 +93,7 @@ async def update_transaction_route(
         setattr(tx, field, value)
     updated = await save_transaction(db, tx)
     logger.info("Transaction %s updated by user %s", transaction_id, current_user.id)
-    await recalc_interest(db, tx.child_id)
+    await post_transaction_update(db, tx.child_id)
     return updated
 
 
@@ -108,7 +108,7 @@ async def delete_transaction_route(
         raise HTTPException(status_code=404, detail="Transaction not found")
     await delete_transaction(db, tx)
     logger.info("Transaction %s deleted by user %s", transaction_id, current_user.id)
-    await recalc_interest(db, tx.child_id)
+    await post_transaction_update(db, tx.child_id)
 
 
 @router.get("/child/{child_id}", response_model=LedgerResponse)

--- a/backend/app/routes/withdrawals.py
+++ b/backend/app/routes/withdrawals.py
@@ -14,6 +14,7 @@ from app.crud import (
     save_withdrawal_request,
     create_transaction,
     get_children_by_user,
+    post_transaction_update,
 )
 from app.schemas import WithdrawalRequestCreate, WithdrawalRequestRead, DenyRequest
 
@@ -72,6 +73,7 @@ async def approve_request(
         initiator_id=req.child_id,
     )
     await create_transaction(db, tx)
+    await post_transaction_update(db, req.child_id)
 
     req.status = "approved"
     req.responded_at = datetime.utcnow()

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -27,6 +27,7 @@ from .recurring import (
     RecurringChargeRead,
     RecurringChargeUpdate,
 )
+from .promotion import Promotion
 
 __all__ = [
     "UserCreate",
@@ -56,4 +57,5 @@ __all__ = [
     "RecurringChargeCreate",
     "RecurringChargeRead",
     "RecurringChargeUpdate",
+    "Promotion",
 ]

--- a/backend/app/schemas/promotion.py
+++ b/backend/app/schemas/promotion.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+
+class Promotion(BaseModel):
+    amount: float
+    is_percentage: bool = False
+    credit: bool = True
+    memo: str | None = None

--- a/backend/app/schemas/settings.py
+++ b/backend/app/schemas/settings.py
@@ -6,6 +6,11 @@ class SettingsRead(BaseModel):
     default_interest_rate: float
     default_penalty_interest_rate: float
     default_cd_penalty_rate: float
+    service_fee_amount: float
+    service_fee_is_percentage: bool
+    overdraft_fee_amount: float
+    overdraft_fee_is_percentage: bool
+    overdraft_fee_daily: bool
 
 
 class SettingsUpdate(BaseModel):
@@ -13,3 +18,8 @@ class SettingsUpdate(BaseModel):
     default_interest_rate: float | None = None
     default_penalty_interest_rate: float | None = None
     default_cd_penalty_rate: float | None = None
+    service_fee_amount: float | None = None
+    service_fee_is_percentage: bool | None = None
+    overdraft_fee_amount: float | None = None
+    overdraft_fee_is_percentage: bool | None = None
+    overdraft_fee_daily: bool | None = None


### PR DESCRIPTION
## Summary
- allow admins to configure service and overdraft fees, with flexible percentage or flat rates
- add overdraft and service fee processing and promotional bulk credits/debits
- expose fee controls and promotions in admin panel

## Testing
- `tests/run`


------
https://chatgpt.com/codex/tasks/task_e_688e40672ba48323b02dbfaccdce79f3