### PR TITLE
Add Caddy reverse proxy to docker-compose

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,7 @@
+:80 {
+    handle_path /api/* {
+        reverse_proxy backend:8000
+    }
+
+    reverse_proxy frontend:80
+}

--- a/README.md
+++ b/README.md
@@ -125,8 +125,8 @@ cd uncle-jons-bank
 docker compose up --build
 ```
 
-FastAPI will be served at: [http://localhost:8000/docs](http://localhost:8000/docs)
-The React frontend will be available at [http://localhost:3000](http://localhost:3000)
+Visit [http://localhost](http://localhost) for the frontend.
+FastAPI's interactive docs are available at [http://localhost/api/docs](http://localhost/api/docs).
 
 ### Migrate DB
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,29 @@
 services:
   backend:
     build: ./backend
-    ports:
-      - "8000:8000"
+    expose:
+      - "8000"
     volumes:
       - ./backend:/app
+
   frontend:
-    build: ./frontend
-    ports:
-      - "3000:80"
+    build:
+      context: ./frontend
+      args:
+        VITE_API_URL: /api
+    expose:
+      - "80"
     volumes:
       - ./frontend:/app
     depends_on:
       - backend
+
+  caddy:
+    image: caddy:alpine
+    ports:
+      - "80:80"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile
+    depends_on:
+      - backend
+      - frontend

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:20 as build
 WORKDIR /app
+ARG VITE_API_URL
+ENV VITE_API_URL=${VITE_API_URL}
 COPY . .
 RUN npm install && npm run build
 


### PR DESCRIPTION
## Summary
- add Caddyfile and Caddy service to docker-compose for single-port deployment
- forward `/api` paths to backend and the rest to frontend
- set frontend build to use `/api` and document new access URLs

## Testing
- `pip install -r backend/requirements.txt`
- `./tests/run`
- `docker compose config` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_688e932c355c83238e46773237529c4f