### PR TITLE
Fix OpenAPI docs under /api prefix

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,6 +4,7 @@ from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from fastapi.openapi.docs import get_swagger_ui_html
+from fastapi.openapi.utils import get_openapi
 from app.routes import (
     users,
     children,
@@ -38,6 +39,23 @@ logging.basicConfig(level=getattr(logging, LOG_LEVEL))
 logger = logging.getLogger(__name__)
 
 app = FastAPI(docs_url=None)
+
+
+def custom_openapi():
+    if app.openapi_schema:
+        return app.openapi_schema
+    openapi_schema = get_openapi(
+        title=app.title,
+        version=app.version,
+        description=app.description,
+        routes=app.routes,
+    )
+    openapi_schema["servers"] = [{"url": "/api"}]
+    app.openapi_schema = openapi_schema
+    return app.openapi_schema
+
+
+app.openapi = custom_openapi
 
 # CORS setup
 app.add_middleware(

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,6 +3,7 @@ import logging
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
+from fastapi.openapi.docs import get_swagger_ui_html
 from app.routes import (
     users,
     children,
@@ -36,7 +37,7 @@ LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
 logging.basicConfig(level=getattr(logging, LOG_LEVEL))
 logger = logging.getLogger(__name__)
 
-app = FastAPI()
+app = FastAPI(docs_url=None)
 
 # CORS setup
 app.add_middleware(
@@ -89,6 +90,15 @@ app.include_router(admin.router)
 app.include_router(tests.router)
 app.include_router(settings.router)
 app.include_router(recurring.router)
+
+
+@app.get("/docs", include_in_schema=False)
+async def custom_swagger_ui_html():
+    # The API is served behind a `/api` prefix by the reverse proxy. The default
+    # FastAPI docs expect the OpenAPI schema at `/openapi.json`, which lives
+    # outside that prefix and results in the Swagger UI failing to load.
+    # Point the docs to `/api/openapi.json` so requests are routed correctly.
+    return get_swagger_ui_html(openapi_url="/api/openapi.json", title="API Docs")
 
 
 @app.get("/")


### PR DESCRIPTION
## Summary
- serve Swagger UI with correct OpenAPI JSON path when app is behind `/api` prefix

## Testing
- `tests/run`


------
https://chatgpt.com/codex/tasks/task_e_688e9ab19d7c8323931cd197fbaf4285