### PR TITLE
Support recurring deposits and currency symbols

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,10 @@ The goal is to teach kids about money through experience — without handing ove
 - Ability to accept offers on Certificates of Deposit (CDs) given by parents.
 - Daily **compound interest**, with optional **bonus tiers** or promotions (Parents can change interest rates at any time)
 - Full ledger of transactions: amount, memo, date, creator, type, promo ID (optional)
+- Monetary amounts display a configurable currency symbol (default `$`).
 
 ### 📆 Recurring Charges, Fees & Promotions
-- **Recurring charges** let parents schedule automatic deductions for regular expenses, like a monthly cell phone plan or an online game subscription.
+- **Recurring charges** let parents schedule automatic deductions for regular expenses, like a monthly cell phone plan or an online game subscription, and now support recurring **credits** for direct deposits.
 - Configure site-wide **service fees** or **overdraft penalties** to teach kids about the cost of banking.
 - Run **promotions** that match deposits, waive fees, or boost interest rates to encourage saving and responsible spending.
 
@@ -144,6 +145,8 @@ and password. Once logged in, visiting `/admin` will attempt to load the admin
 interface. The React app checks your role by calling the `/users/me` endpoint in
 `frontend/src/App.tsx`; if it returns an account with the `admin` role, the
 admin panel is displayed.
+
+Admins can also set the site's default currency symbol (defaults to `$`), which is used throughout the interface when displaying monetary amounts.
 
 ## 🧪 Testing
 

--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -770,7 +770,7 @@ async def process_due_recurring_charges(db: AsyncSession) -> None:
                 db,
                 Transaction(
                     child_id=charge.child_id,
-                    type="debit",
+                    type=charge.type,
                     amount=charge.amount,
                     memo=charge.memo,
                     initiated_by="system",

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -78,6 +78,20 @@ async def create_db_and_tables() -> None:
                     "ALTER TABLE settings ADD COLUMN overdraft_fee_daily BOOLEAN DEFAULT 0"
                 )
             )
+        if not await has_column("settings", "currency_symbol"):
+            await conn.execute(
+                text(
+                    "ALTER TABLE settings ADD COLUMN currency_symbol VARCHAR DEFAULT '$'"
+                )
+            )
+
+        # RecurringCharge table columns
+        if not await has_column("recurringcharge", "type"):
+            await conn.execute(
+                text(
+                    "ALTER TABLE recurringcharge ADD COLUMN type VARCHAR DEFAULT 'debit'"
+                )
+            )
 
         # Account table columns
         if not await has_column("account", "service_fee_last_charged"):

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -113,6 +113,7 @@ class RecurringCharge(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
     child_id: int = Field(foreign_key="child.id")
     amount: float
+    type: str = "debit"  # "credit" or "debit"
     memo: Optional[str] = None
     interval_days: int
     next_run: date
@@ -149,3 +150,4 @@ class Settings(SQLModel, table=True):
     overdraft_fee_amount: float = 0.0
     overdraft_fee_is_percentage: bool = False
     overdraft_fee_daily: bool = False
+    currency_symbol: str = "$"

--- a/backend/app/routes/recurring.py
+++ b/backend/app/routes/recurring.py
@@ -51,6 +51,7 @@ async def add_recurring_charge(
     rc = RecurringCharge(
         child_id=child_id,
         amount=data.amount,
+        type=data.type,
         memo=data.memo,
         interval_days=data.interval_days,
         next_run=data.next_run,

--- a/backend/app/routes/settings.py
+++ b/backend/app/routes/settings.py
@@ -23,6 +23,7 @@ async def read_settings(db: AsyncSession = Depends(get_session)):
         overdraft_fee_amount=settings.overdraft_fee_amount,
         overdraft_fee_is_percentage=settings.overdraft_fee_is_percentage,
         overdraft_fee_daily=settings.overdraft_fee_daily,
+        currency_symbol=settings.currency_symbol,
     )
 
 
@@ -46,4 +47,5 @@ async def update_settings(
         overdraft_fee_amount=updated.overdraft_fee_amount,
         overdraft_fee_is_percentage=updated.overdraft_fee_is_percentage,
         overdraft_fee_daily=updated.overdraft_fee_daily,
+        currency_symbol=updated.currency_symbol,
     )

--- a/backend/app/schemas/recurring.py
+++ b/backend/app/schemas/recurring.py
@@ -5,6 +5,7 @@ from datetime import date
 
 class RecurringChargeBase(BaseModel):
     amount: float
+    type: str = "debit"
     memo: Optional[str] = None
     interval_days: int
     next_run: date
@@ -25,6 +26,7 @@ class RecurringChargeRead(RecurringChargeBase):
 
 class RecurringChargeUpdate(BaseModel):
     amount: float | None = None
+    type: str | None = None
     memo: str | None = None
     interval_days: int | None = None
     next_run: date | None = None

--- a/backend/app/schemas/settings.py
+++ b/backend/app/schemas/settings.py
@@ -11,6 +11,7 @@ class SettingsRead(BaseModel):
     overdraft_fee_amount: float
     overdraft_fee_is_percentage: bool
     overdraft_fee_daily: bool
+    currency_symbol: str
 
 
 class SettingsUpdate(BaseModel):
@@ -23,3 +24,4 @@ class SettingsUpdate(BaseModel):
     overdraft_fee_amount: float | None = None
     overdraft_fee_is_percentage: bool | None = None
     overdraft_fee_daily: bool | None = None
+    currency_symbol: str | None = None

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,6 +18,7 @@ function App() {
   const [isAdmin, setIsAdmin] = useState(false)
   const [permissions, setPermissions] = useState<string[]>([])
   const [siteName, setSiteName] = useState("Uncle Jon's Bank")
+  const [currencySymbol, setCurrencySymbol] = useState('$')
   const [theme, setTheme] = useState<'light' | 'dark'>(() =>
     document.documentElement.classList.contains('dark') ? 'dark' : 'light',
   )
@@ -75,6 +76,7 @@ function App() {
     if (resp.ok) {
       const data = await resp.json()
       setSiteName(data.site_name)
+      setCurrencySymbol(data.currency_symbol || '$')
       document.title = data.site_name
     }
   }, [apiUrl])
@@ -101,17 +103,22 @@ function App() {
       <Routes>
         {isChildAccount && childId !== null && (
           <>
-            <Route path="/child" element={<ChildDashboard token={token} childId={childId} apiUrl={apiUrl} onLogout={handleLogout} />} />
+            <Route path="/child" element={<ChildDashboard token={token} childId={childId} apiUrl={apiUrl} onLogout={handleLogout} currencySymbol={currencySymbol} />} />
             <Route path="/child/profile" element={<ChildProfile token={token} apiUrl={apiUrl} />} />
           </>
         )}
         {!isChildAccount && (
           <Route
             path="/"
-            element={<ParentDashboard token={token} apiUrl={apiUrl} permissions={permissions} onLogout={handleLogout} />}
+            element={<ParentDashboard token={token} apiUrl={apiUrl} permissions={permissions} onLogout={handleLogout} currencySymbol={currencySymbol} />}
           />
         )}
-        {isAdmin && <Route path="/admin" element={<AdminPanel token={token} apiUrl={apiUrl} onLogout={handleLogout} siteName={siteName} />} />}
+        {isAdmin && (
+          <Route
+            path="/admin"
+            element={<AdminPanel token={token} apiUrl={apiUrl} onLogout={handleLogout} siteName={siteName} currencySymbol={currencySymbol} onSettingsChange={fetchSettings} />}
+          />
+        )}
         <Route path="*" element={<Navigate to={isChildAccount ? '/child' : '/'} replace />} />
       </Routes>
     </BrowserRouter>

--- a/frontend/src/components/EditSiteSettingsModal.tsx
+++ b/frontend/src/components/EditSiteSettingsModal.tsx
@@ -10,6 +10,7 @@ interface SiteSettings {
   overdraft_fee_amount: number
   overdraft_fee_is_percentage: boolean
   overdraft_fee_daily: boolean
+  currency_symbol: string
 }
 
 interface Props {
@@ -31,6 +32,7 @@ export default function EditSiteSettingsModal({ settings, token, apiUrl, onClose
     overdraft_fee_amount: settings.overdraft_fee_amount.toString(),
     overdraft_fee_is_percentage: settings.overdraft_fee_is_percentage,
     overdraft_fee_daily: settings.overdraft_fee_daily,
+    currency_symbol: settings.currency_symbol,
   })
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -53,6 +55,7 @@ export default function EditSiteSettingsModal({ settings, token, apiUrl, onClose
         overdraft_fee_amount: Number(form.overdraft_fee_amount),
         overdraft_fee_is_percentage: form.overdraft_fee_is_percentage,
         overdraft_fee_daily: form.overdraft_fee_daily,
+        currency_symbol: form.currency_symbol,
       })
     })
     onSaved()
@@ -67,6 +70,10 @@ export default function EditSiteSettingsModal({ settings, token, apiUrl, onClose
           <label>
             Site Name
             <input name="site_name" value={form.site_name} onChange={handleChange} required />
+          </label>
+          <label>
+            Currency Symbol
+            <input name="currency_symbol" value={form.currency_symbol} onChange={handleChange} required />
           </label>
           <label>
             Default Interest Rate

--- a/frontend/src/components/LedgerTable.tsx
+++ b/frontend/src/components/LedgerTable.tsx
@@ -1,4 +1,5 @@
 import React, { useLayoutEffect, useRef, useState, useMemo } from 'react'
+import { formatCurrency } from '../utils/currency'
 
 export interface Transaction {
   id: number
@@ -16,11 +17,13 @@ export default function LedgerTable({
   renderActions,
   onWidth,
   allowDownload,
+  currencySymbol,
 }: {
   transactions: Transaction[]
   renderActions?: (tx: Transaction) => React.ReactNode
   onWidth?: (width: number) => void
   allowDownload?: boolean
+  currencySymbol: string
 }) {
   const tableRef = useRef<HTMLTableElement>(null)
   const [pageSize, setPageSize] = useState(15)
@@ -85,9 +88,9 @@ export default function LedgerTable({
         <td>{new Date(tx.timestamp).toLocaleDateString()}</td>
         <td>{tx.type}</td>
         <td>{tx.memo || ''}</td>
-        <td>{tx.type === 'debit' ? tx.amount.toFixed(2) : ''}</td>
-        <td>{tx.type === 'credit' ? tx.amount.toFixed(2) : ''}</td>
-        <td>{runningBalance.toFixed(2)}</td>
+        <td>{tx.type === 'debit' ? formatCurrency(tx.amount, currencySymbol) : ''}</td>
+        <td>{tx.type === 'credit' ? formatCurrency(tx.amount, currencySymbol) : ''}</td>
+        <td>{formatCurrency(runningBalance, currencySymbol)}</td>
         {renderActions && <td>{renderActions(tx)}</td>}
       </tr>
     )
@@ -114,9 +117,9 @@ export default function LedgerTable({
         new Date(tx.timestamp).toLocaleDateString(),
         tx.type,
         tx.memo || '',
-        tx.type === 'debit' ? tx.amount.toFixed(2) : '',
-        tx.type === 'credit' ? tx.amount.toFixed(2) : '',
-        bal.toFixed(2),
+        tx.type === 'debit' ? formatCurrency(tx.amount, currencySymbol) : '',
+        tx.type === 'credit' ? formatCurrency(tx.amount, currencySymbol) : '',
+        formatCurrency(bal, currencySymbol),
       ])
     })
     const csv = rows.map(r => r.map(v => `"${String(v).replace(/"/g, '""')}"`).join(',')).join('\n')

--- a/frontend/src/utils/currency.ts
+++ b/frontend/src/utils/currency.ts
@@ -1,0 +1,3 @@
+export function formatCurrency(amount: number, symbol: string): string {
+  return `${symbol}${amount.toFixed(2)}`;
+}


### PR DESCRIPTION
## Summary
- allow recurring transactions to be credits or debits
- add configurable currency symbol and show it before all amounts
- surface currency symbol setting in the admin UI

## Testing
- `./tests/run`


------
https://chatgpt.com/codex/tasks/task_e_688ecc56e7108323acb99f1cdd3e7df8