### PR TITLE
Fix logout cache and respect JWT expiry config

### DIFF
--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -20,7 +20,10 @@ import os
 
 SECRET_KEY = os.getenv("SECRET_KEY", "super-secret-key")
 ALGORITHM = "HS256"
-ACCESS_TOKEN_EXPIRE_MINUTES = 30
+# Default token expiration in minutes, overridable via environment variable
+ACCESS_TOKEN_EXPIRE_MINUTES = int(
+    os.getenv("ACCESS_TOKEN_EXPIRE_MINUTES", "30")
+)
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/token")
@@ -59,7 +62,9 @@ def create_access_token(data: dict, expires_delta: timedelta | None = None):
     """Generate a signed JWT token containing ``data``."""
 
     to_encode = data.copy()
-    expire = datetime.utcnow() + (expires_delta or timedelta(minutes=15))
+    expire = datetime.utcnow() + (
+        expires_delta or timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
+    )
     to_encode.update({"exp": expire})
     return jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
 

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -16,7 +16,6 @@ from app.models import User
 
 from sqlmodel import select
 from app.schemas.user import UserCreate, UserResponse, UserLogin
-from datetime import timedelta
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -41,9 +40,7 @@ async def login_for_access_token(
             },
         )
     logger.info("User %s logged in via OAuth form", user.email)
-    access_token = create_access_token(
-        data={"sub": user.email}, expires_delta=timedelta(minutes=60)
-    )
+    access_token = create_access_token(data={"sub": user.email})
     return {"access_token": access_token, "token_type": "bearer"}
 
 
@@ -65,9 +62,7 @@ async def login(user_in: UserLogin, db: AsyncSession = Depends(get_session)):
             },
         )
     logger.info("User %s logged in", user.email)
-    access_token = create_access_token(
-        data={"sub": user.email}, expires_delta=timedelta(minutes=60)
-    )
+    access_token = create_access_token(data={"sub": user.email})
     return {"access_token": access_token, "token_type": "bearer"}
 
 @router.post("/register", response_model=UserResponse)

--- a/backend/app/routes/children.py
+++ b/backend/app/routes/children.py
@@ -1,6 +1,5 @@
 """Routes for managing child accounts and related settings."""
 
-from datetime import timedelta
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 from app.schemas import (
@@ -307,7 +306,5 @@ async def child_login(
         raise HTTPException(status_code=401, detail="Invalid access code")
     if child.account_frozen:
         raise HTTPException(status_code=403, detail="Account is frozen")
-    token = create_access_token(
-        data={"sub": f"child:{child.id}"}, expires_delta=timedelta(minutes=60)
-    )
+    token = create_access_token(data={"sub": f"child:{child.id}"})
     return {"access_token": token, "token_type": "bearer"}

--- a/backend/app/tests/test_token_expiration.py
+++ b/backend/app/tests/test_token_expiration.py
@@ -1,0 +1,18 @@
+from datetime import datetime
+import importlib
+from jose import jwt
+
+
+def test_access_token_expiration_respects_env(monkeypatch):
+    monkeypatch.setenv("ACCESS_TOKEN_EXPIRE_MINUTES", "1")
+    import app.auth as auth
+    importlib.reload(auth)
+
+    token = auth.create_access_token(data={"sub": "test"})
+    decoded = jwt.decode(token, auth.SECRET_KEY, algorithms=[auth.ALGORITHM])
+    exp = datetime.utcfromtimestamp(decoded["exp"])
+    delta = exp - datetime.utcnow()
+    assert 45 <= delta.total_seconds() <= 75
+
+    monkeypatch.delenv("ACCESS_TOKEN_EXPIRE_MINUTES", raising=False)
+    importlib.reload(auth)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -42,11 +42,13 @@ function App() {
     }
   }
 
-  // Clear authentication information when logging out.
+  // Clear authentication information and any cached role data when logging out.
   const handleLogout = () => {
     setToken(null)
     setIsChildAccount(false)
     setChildId(null)
+    setIsAdmin(false)
+    setPermissions([])
     localStorage.removeItem('token')
     localStorage.removeItem('isChild')
     localStorage.removeItem('childId')


### PR DESCRIPTION
## Summary
- clear cached admin/permission state when logging out to prevent cross-account leakage
- derive JWT expiration from `ACCESS_TOKEN_EXPIRE_MINUTES` environment variable and use it across token issuance
- add test verifying token expiration honors the configured value

## Testing
- `npm run lint`
- `./tests/run`


------
https://chatgpt.com/codex/tasks/task_e_688f9119a6ec832388807c4f85cd67ef