### PR TITLE
Add parent profile and account management improvements

### DIFF
--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -1,4 +1,10 @@
-from .user import UserCreate, UserResponse, UserUpdate, UserMeResponse
+from .user import (
+    UserCreate,
+    UserResponse,
+    UserUpdate,
+    UserMeResponse,
+    PasswordChange,
+)
 """Convenience imports for all schema classes used by the API."""
 
 from .child import (
@@ -9,6 +15,7 @@ from .child import (
     PenaltyRateUpdate,
     CDPenaltyRateUpdate,
     ChildUpdate,
+    AccessCodeUpdate,
 )
 from .transaction import (
     TransactionCreate,
@@ -36,9 +43,11 @@ __all__ = [
     "UserResponse",
     "UserMeResponse",
     "UserUpdate",
+    "PasswordChange",
     "ChildCreate",
     "ChildRead",
     "ChildUpdate",
+    "AccessCodeUpdate",
     "ChildLogin",
     "InterestRateUpdate",
     "PenaltyRateUpdate",

--- a/backend/app/schemas/child.py
+++ b/backend/app/schemas/child.py
@@ -45,3 +45,7 @@ class ChildUpdate(BaseModel):
     first_name: str | None = None
     access_code: str | None = None
     frozen: bool | None = None
+
+
+class AccessCodeUpdate(BaseModel):
+    access_code: str

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -32,3 +32,7 @@ class UserUpdate(BaseModel):
     email: EmailStr | None = None
     role: str | None = None
     password: str | None = None
+
+
+class PasswordChange(BaseModel):
+    password: str

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback } from 'react'
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
 import LoginPage from './pages/LoginPage'
 import ParentDashboard from './pages/ParentDashboard'
+import ParentProfile from './pages/ParentProfile'
 import ChildDashboard from './pages/ChildDashboard'
 import ChildProfile from './pages/ChildProfile'
 import AdminPanel from './pages/AdminPanel'
@@ -117,10 +118,16 @@ function App() {
           </>
         )}
         {!isChildAccount && (
-          <Route
-            path="/"
-            element={<ParentDashboard token={token} apiUrl={apiUrl} permissions={permissions} onLogout={handleLogout} currencySymbol={currencySymbol} />}
-          />
+          <>
+            <Route
+              path="/"
+              element={<ParentDashboard token={token} apiUrl={apiUrl} permissions={permissions} onLogout={handleLogout} currencySymbol={currencySymbol} />}
+            />
+            <Route
+              path="/parent/profile"
+              element={<ParentProfile token={token} apiUrl={apiUrl} />}
+            />
+          </>
         )}
         {isAdmin && (
           <Route

--- a/frontend/src/components/EditRatesModal.tsx
+++ b/frontend/src/components/EditRatesModal.tsx
@@ -26,20 +26,24 @@ export default function EditRatesModal({
   onError,
 }: Props) {
   const [interest, setInterest] = useState(
-    child.interest_rate?.toString() ?? "",
+    child.interest_rate != null ? (child.interest_rate * 100).toString() : "",
   );
   const [penalty, setPenalty] = useState(
-    child.penalty_interest_rate?.toString() ?? "",
+    child.penalty_interest_rate != null
+      ? (child.penalty_interest_rate * 100).toString()
+      : "",
   );
   const [cdPenalty, setCdPenalty] = useState(
-    child.cd_penalty_rate?.toString() ?? "",
+    child.cd_penalty_rate != null
+      ? (child.cd_penalty_rate * 100).toString()
+      : "",
   );
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
-    const i = Number(interest);
-    const p = Number(penalty);
-    const cdr = Number(cdPenalty);
+    const i = Number(interest) / 100;
+    const p = Number(penalty) / 100;
+    const cdr = Number(cdPenalty) / 100;
     if (Number.isNaN(i) || Number.isNaN(p) || Number.isNaN(cdr)) {
       onError("Please enter valid numbers for all rates.");
       return;
@@ -92,30 +96,36 @@ export default function EditRatesModal({
       <div className="modal">
         <h3>Edit Rates for {child.first_name}</h3>
         <form onSubmit={handleSubmit} className="form">
-          <input
-            type="number"
-            step="0.0001"
-            placeholder="Interest rate"
-            value={interest}
-            onChange={(e) => setInterest(e.target.value)}
-            required
-          />
-          <input
-            type="number"
-            step="0.0001"
-            placeholder="Penalty interest rate"
-            value={penalty}
-            onChange={(e) => setPenalty(e.target.value)}
-            required
-          />
-          <input
-            type="number"
-            step="0.0001"
-            placeholder="CD penalty rate"
-            value={cdPenalty}
-            onChange={(e) => setCdPenalty(e.target.value)}
-            required
-          />
+          <label>
+            Interest rate
+            <input
+              type="number"
+              step="0.01"
+              value={interest}
+              onChange={(e) => setInterest(e.target.value)}
+              required
+            />%
+          </label>
+          <label>
+            Penalty interest rate
+            <input
+              type="number"
+              step="0.01"
+              value={penalty}
+              onChange={(e) => setPenalty(e.target.value)}
+              required
+            />%
+          </label>
+          <label>
+            CD penalty rate
+            <input
+              type="number"
+              step="0.01"
+              value={cdPenalty}
+              onChange={(e) => setCdPenalty(e.target.value)}
+              required
+            />%
+          </label>
           <div className="modal-actions">
             <button type="submit">Save</button>
             <button type="button" className="ml-1" onClick={onClose}>

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -22,7 +22,10 @@ export default function Header({ onLogout, isAdmin, isChild, siteName, onToggleT
                 <li><Link to="/child/profile">Profile</Link></li>
               </>
             ) : (
-              <li><Link to="/">Dashboard</Link></li>
+              <>
+                <li><Link to="/">Dashboard</Link></li>
+                <li><Link to="/parent/profile">Profile</Link></li>
+              </>
             )}
           {isAdmin && <li><Link to="/admin">Admin</Link></li>}
           <li><button onClick={onToggleTheme}>{theme === 'dark' ? 'Light Mode' : 'Dark Mode'}</button></li>

--- a/frontend/src/pages/ParentDashboard.tsx
+++ b/frontend/src/pages/ParentDashboard.tsx
@@ -99,6 +99,7 @@ export default function ParentDashboard({
   const [ratesMessage, setRatesMessage] = useState<string | null>(null);
   const [ratesError, setRatesError] = useState(false);
   const [editingTx, setEditingTx] = useState<Transaction | null>(null);
+  const [codeChild, setCodeChild] = useState<Child | null>(null);
   const canEdit = permissions.includes("edit_transaction");
   const canDelete = permissions.includes("delete_transaction");
   const canAddRecurring = permissions.includes("add_recurring_charge");
@@ -194,6 +195,12 @@ export default function ParentDashboard({
                 className="ml-1"
               >
                 {c.frozen ? "Unfreeze" : "Freeze"}
+              </button>
+              <button
+                onClick={() => setCodeChild(c)}
+                className="ml-1"
+              >
+                Change Code
               </button>
               <button
                 onClick={() => {
@@ -588,6 +595,31 @@ export default function ParentDashboard({
           onError={(msg) => {
             setRatesMessage(msg);
             setRatesError(true);
+          }}
+        />
+      )}
+      {codeChild && (
+        <TextPromptModal
+          title={`New access code for ${codeChild.first_name}`}
+          label="Access Code"
+          onCancel={() => setCodeChild(null)}
+          onSubmit={async (value) => {
+            const resp = await fetch(
+              `${apiUrl}/children/${codeChild.id}/access-code`,
+              {
+                method: "PUT",
+                headers: {
+                  "Content-Type": "application/json",
+                  Authorization: `Bearer ${token}`,
+                },
+                body: JSON.stringify({ access_code: value }),
+              },
+            );
+            if (!resp.ok) {
+              alert("Failed to update access code");
+            }
+            setCodeChild(null);
+            fetchChildren();
           }}
         />
       )}

--- a/frontend/src/pages/ParentProfile.tsx
+++ b/frontend/src/pages/ParentProfile.tsx
@@ -1,0 +1,95 @@
+import { useEffect, useState, FormEvent } from 'react'
+
+interface Props {
+  token: string
+  apiUrl: string
+}
+
+interface UserData {
+  name: string
+  email: string
+  permissions: string[]
+}
+
+export default function ParentProfile({ token, apiUrl }: Props) {
+  const [data, setData] = useState<UserData | null>(null)
+  const [newPassword, setNewPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+  const [message, setMessage] = useState<string | null>(null)
+  const [error, setError] = useState(false)
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const resp = await fetch(`${apiUrl}/users/me`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      if (resp.ok) setData(await resp.json())
+    }
+    fetchData()
+  }, [token, apiUrl])
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault()
+    if (newPassword !== confirmPassword) {
+      setMessage('Passwords do not match')
+      setError(true)
+      return
+    }
+    const resp = await fetch(`${apiUrl}/users/me/password`, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ password: newPassword }),
+    })
+    if (resp.ok) {
+      setMessage('Password updated successfully.')
+      setError(false)
+      setNewPassword('')
+      setConfirmPassword('')
+    } else {
+      setMessage('Failed to update password.')
+      setError(true)
+    }
+  }
+
+  if (!data) return <p>Loading...</p>
+
+  return (
+    <div className="container">
+      <h2>Your Profile</h2>
+      <p>Email: {data.email}</p>
+      <p>Permissions:</p>
+      <ul>
+        {data.permissions.map((p) => (
+          <li key={p}>{p}</li>
+        ))}
+      </ul>
+      <form onSubmit={handleSubmit} className="form">
+        <h4>Change Password</h4>
+        {message && <p className={error ? 'error' : 'success'}>{message}</p>}
+        <label>
+          New Password
+          <input
+            type="password"
+            value={newPassword}
+            onChange={(e) => setNewPassword(e.target.value)}
+            required
+          />
+        </label>
+        <label>
+          Confirm Password
+          <input
+            type="password"
+            value={confirmPassword}
+            onChange={(e) => setConfirmPassword(e.target.value)}
+            required
+          />
+        </label>
+        <button type="submit">Update Password</button>
+      </form>
+    </div>
+  )
+}
+


### PR DESCRIPTION
## Summary
- add parent profile page with permission list and password change
- allow updating a child's access code
- make rate editor use labeled percentage fields

## Testing
- `python -m app.tests.api_tests`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f926538a08323a1648ce0e516d139