### PR TITLE
Improve dashboard accessibility and mobile UX

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -61,13 +61,36 @@
   text-align: left;
 }
 
-.child-row {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
+.child-card {
+  border: 1px solid var(--container-border, #ccc);
+  border-radius: 4px;
+  margin-bottom: 0.5rem;
 }
-.child-row span:first-child {
-  flex: 1;
+.child-card summary {
+  padding: 0.5rem;
+  cursor: pointer;
+}
+.child-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.5rem;
+}
+.child-actions button {
+  width: 100%;
+}
+@media (min-width: 600px) {
+  .child-actions {
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+  .child-actions button {
+    flex: 1 0 45%;
+  }
+}
+
+.ledger-scroll {
+  overflow-x: auto;
 }
 
 .ml-1 {
@@ -203,6 +226,8 @@
   border-radius: 8px;
   max-width: 300px;
   width: 100%;
+  max-height: 90vh;
+  overflow-y: auto;
 }
 
 .modal-actions {

--- a/frontend/src/components/EditRatesModal.tsx
+++ b/frontend/src/components/EditRatesModal.tsx
@@ -96,7 +96,7 @@ export default function EditRatesModal({
       <div className="modal">
         <h3>Edit Rates for {child.first_name}</h3>
         <form onSubmit={handleSubmit} className="form">
-          <label>
+          <label title="Annual percentage yield paid on savings">
             Interest rate
             <input
               type="number"
@@ -106,7 +106,7 @@ export default function EditRatesModal({
               required
             />%
           </label>
-          <label>
+          <label title="Rate charged when an account is overdrawn or in penalty">
             Penalty interest rate
             <input
               type="number"
@@ -116,7 +116,7 @@ export default function EditRatesModal({
               required
             />%
           </label>
-          <label>
+          <label title="Penalty for early withdrawal from a certificate of deposit">
             CD penalty rate
             <input
               type="number"

--- a/frontend/src/components/EditRecurringModal.tsx
+++ b/frontend/src/components/EditRecurringModal.tsx
@@ -1,0 +1,143 @@
+import { useState } from "react";
+
+interface RecurringCharge {
+  id: number;
+  child_id: number;
+  amount: number;
+  type: string;
+  memo?: string | null;
+  interval_days: number;
+  next_run: string;
+  active: boolean;
+}
+
+interface Props {
+  charge: RecurringCharge;
+  token: string;
+  apiUrl: string;
+  onClose: () => void;
+  onSaved: () => void;
+}
+
+export default function EditRecurringModal({
+  charge,
+  token,
+  apiUrl,
+  onClose,
+  onSaved,
+}: Props) {
+  const [amount, setAmount] = useState(String(charge.amount));
+  const [type, setType] = useState(charge.type);
+  const [memo, setMemo] = useState(charge.memo || "");
+  const [interval, setInterval] = useState(String(charge.interval_days));
+  const [next, setNext] = useState(charge.next_run.slice(0, 10));
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    const amt = Number(amount);
+    const intDays = Number(interval);
+    if (isNaN(amt) || amt <= 0) {
+      setError("Amount must be positive");
+      return;
+    }
+    if (isNaN(intDays) || intDays <= 0) {
+      setError("Interval must be positive");
+      return;
+    }
+    setLoading(true);
+    try {
+      const resp = await fetch(`${apiUrl}/recurring/${charge.id}`, {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({
+          amount: amt,
+          interval_days: intDays,
+          memo: memo || null,
+          next_run: next,
+          type,
+        }),
+      });
+      if (resp.ok) {
+        onSaved();
+        onClose();
+      } else {
+        const data = await resp.json().catch(() => null);
+        setError(data?.message || "Failed to update charge");
+      }
+    } catch (err) {
+      console.error(err);
+      setError("Failed to update charge");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="modal-overlay">
+      <div className="modal">
+        <h4>Edit Recurring Charge</h4>
+        {error && <p className="error">{error}</p>}
+        <form onSubmit={handleSubmit} className="form">
+          <label>
+            Amount
+            <input
+              type="number"
+              step="0.01"
+              value={amount}
+              onChange={(e) => setAmount(e.target.value)}
+              required
+            />
+          </label>
+          <label>
+            Type
+            <select value={type} onChange={(e) => setType(e.target.value)}>
+              <option value="debit">Debit</option>
+              <option value="credit">Credit</option>
+            </select>
+          </label>
+          <label>
+            Memo
+            <input value={memo} onChange={(e) => setMemo(e.target.value)} />
+          </label>
+          <label>
+            Interval days
+            <input
+              type="number"
+              value={interval}
+              onChange={(e) => setInterval(e.target.value)}
+              required
+            />
+          </label>
+          <label>
+            Next run
+            <input
+              type="date"
+              value={next}
+              onChange={(e) => setNext(e.target.value)}
+              required
+            />
+          </label>
+          <div className="modal-actions">
+            <button type="submit" disabled={loading}>
+              Save
+            </button>
+            <button
+              type="button"
+              className="ml-05"
+              onClick={onClose}
+              disabled={loading}
+            >
+              Cancel
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Replace prompt-based recurring charge edits with a dedicated modal
- Convert child rows to collapsible cards with accessible form labels
- Add tooltips and responsive modal behavior for better mobile experience

## Testing
- `npm run lint`
- `npm run build`
- `./tests/run`


------
https://chatgpt.com/codex/tasks/task_e_688f964816748323904fe9862d1b031b