### PR TITLE
Add overlaps to user permissions relationship

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -46,7 +46,9 @@ class User(SQLModel, table=True):
         back_populates="user"
     )
     permissions: List[Permission] = Relationship(
-        back_populates="users", link_model=UserPermissionLink
+        back_populates="users",
+        link_model=UserPermissionLink,
+        sa_relationship_kwargs={"overlaps": "permission,user_links"},
     )
 
 


### PR DESCRIPTION
## Summary
- specify overlapping relationships for `User.permissions` to handle joined tables

## Testing
- `./tests/run`

------
https://chatgpt.com/codex/tasks/task_e_688f9905d2188323a9ac1c5b1ba94494