### PR TITLE
Specify overlaps on Permission.users relationship

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -29,7 +29,9 @@ class Permission(SQLModel, table=True):
         back_populates="permission"
     )
     users: List["User"] = Relationship(
-        back_populates="permissions", link_model=UserPermissionLink
+        back_populates="permissions",
+        link_model=UserPermissionLink,
+        sa_relationship_kwargs={"overlaps": "user_links,permission,user"},
     )
 
 


### PR DESCRIPTION
## Summary
- add overlap hints to Permission.users relationship to avoid relationship conflicts

## Testing
- `./tests/run`


------
https://chatgpt.com/codex/tasks/task_e_688f9d5d51b883238b19a70f7462da63