### PR TITLE
Fix recurring task date handling and validation

### DIFF
--- a/frontend/src/components/EditRecurringModal.tsx
+++ b/frontend/src/components/EditRecurringModal.tsx
@@ -47,6 +47,13 @@ export default function EditRecurringModal({
       setError("Interval must be positive");
       return;
     }
+    const nextDate = new Date(next + "T00:00:00");
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    if (nextDate < today) {
+      setError("Next run cannot be in the past");
+      return;
+    }
     setLoading(true);
     try {
       const resp = await fetch(`${apiUrl}/recurring/${charge.id}`, {

--- a/frontend/src/pages/ChildDashboard.tsx
+++ b/frontend/src/pages/ChildDashboard.tsx
@@ -140,7 +140,7 @@ export default function ChildDashboard({ token, childId, apiUrl, onLogout, curre
           <ul className="list">
             {charges.map(c => (
               <li key={c.id}>
-                {c.type} {formatCurrency(c.amount, currencySymbol)} every {c.interval_days} days next on {new Date(c.next_run).toLocaleDateString()} {c.memo ? `(${c.memo})` : ''}
+                {c.type} {formatCurrency(c.amount, currencySymbol)} every {c.interval_days} days next on {new Date(c.next_run + "T00:00:00").toLocaleDateString()} {c.memo ? `(${c.memo})` : ''}
               </li>
             ))}
           </ul>

--- a/frontend/src/pages/ParentDashboard.tsx
+++ b/frontend/src/pages/ParentDashboard.tsx
@@ -265,7 +265,7 @@ export default function ParentDashboard({
           <ul className="list">
             {charges.map((c) => (
               <li key={c.id}>
-                {c.type} {formatCurrency(c.amount, currencySymbol)} every {c.interval_days} days next on {new Date(c.next_run).toLocaleDateString()} {c.memo ? `(${c.memo})` : ""}
+                {c.type} {formatCurrency(c.amount, currencySymbol)} every {c.interval_days} days next on {new Date(c.next_run + "T00:00:00").toLocaleDateString()} {c.memo ? `(${c.memo})` : ""}
                 {canEditRecurring && (
                   <button
                     onClick={() => setEditingCharge(c)}
@@ -298,8 +298,15 @@ export default function ParentDashboard({
           </ul>
           {canAddRecurring && (
             <form
-              onSubmit={async (e) => {
-                e.preventDefault();
+            onSubmit={async (e) => {
+              e.preventDefault();
+                const nextDate = new Date(rcNext + "T00:00:00");
+                const today = new Date();
+                today.setHours(0, 0, 0, 0);
+                if (nextDate < today) {
+                  setToast({ message: "Next run cannot be in the past", error: true });
+                  return;
+                }
                 await fetch(`${apiUrl}/recurring/child/${selectedChild}`, {
                   method: "POST",
                   headers: {


### PR DESCRIPTION
## Summary
- prevent recurring tasks from being created or updated with past start dates
- parse recurring task dates in local time to avoid off-by-one-day display
- block client-side submissions with past dates

## Testing
- `tests/run`
- `cd frontend && npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688f9e80725c8323a525a2c6facaf3aa