### PR TITLE
fix: silence relationship overlaps warning

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -45,7 +45,8 @@ class User(SQLModel, table=True):
 
     children: List["ChildUserLink"] = Relationship(back_populates="user")
     permission_links: List["UserPermissionLink"] = Relationship(
-        back_populates="user"
+        back_populates="user",
+        sa_relationship_kwargs={"overlaps": "users"},
     )
     permissions: List[Permission] = Relationship(
         back_populates="users",


### PR DESCRIPTION
## Summary
- add SQLAlchemy `overlaps` directive to `User.permission_links`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688fa02902888323998345342819be20