### PR TITLE
fix: adjust user permissions overlap

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -51,7 +51,7 @@ class User(SQLModel, table=True):
     permissions: List[Permission] = Relationship(
         back_populates="users",
         link_model=UserPermissionLink,
-        sa_relationship_kwargs={"overlaps": "permission,user_links"},
+        sa_relationship_kwargs={"overlaps": "permission_links,user"},
     )
 
 


### PR DESCRIPTION
## Summary
- adjust User.permissions relationship overlap to include permission_links and user

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688fa106a6a083238560080fd4776939