### PR TITLE
Allow children to cancel requests and improve dashboard messaging

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -120,7 +120,7 @@ class WithdrawalRequest(SQLModel, table=True):
     child_id: int = Field(foreign_key="child.id")
     amount: float
     memo: Optional[str] = None
-    status: str = "pending"  # pending, approved, denied
+    status: str = "pending"  # pending, approved, denied, cancelled
     requested_at: datetime = Field(default_factory=datetime.utcnow)
     responded_at: Optional[datetime] = None
     approver_id: Optional[int] = Field(default=None, foreign_key="user.id")

--- a/backend/app/routes/withdrawals.py
+++ b/backend/app/routes/withdrawals.py
@@ -102,3 +102,18 @@ async def deny_request(
     req.approver_id = current_user.id
     await save_withdrawal_request(db, req)
     return req
+
+
+@router.post("/{request_id}/cancel", response_model=WithdrawalRequestRead)
+async def cancel_request(
+    request_id: int,
+    db: AsyncSession = Depends(get_session),
+    child: Child = Depends(get_current_child),
+):
+    req = await get_withdrawal_request(db, request_id)
+    if not req or req.status != "pending" or req.child_id != child.id:
+        raise HTTPException(status_code=404, detail="Request not found")
+    req.status = "cancelled"
+    req.responded_at = datetime.utcnow()
+    await save_withdrawal_request(db, req)
+    return req

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -114,7 +114,7 @@ function App() {
         {isChildAccount && childId !== null && (
           <>
             <Route path="/child" element={<ChildDashboard token={token} childId={childId} apiUrl={apiUrl} onLogout={handleLogout} currencySymbol={currencySymbol} />} />
-            <Route path="/child/profile" element={<ChildProfile token={token} apiUrl={apiUrl} />} />
+              <Route path="/child/profile" element={<ChildProfile token={token} apiUrl={apiUrl} currencySymbol={currencySymbol} />} />
           </>
         )}
         {!isChildAccount && (

--- a/frontend/src/pages/ChildDashboard.tsx
+++ b/frontend/src/pages/ChildDashboard.tsx
@@ -83,6 +83,14 @@ export default function ChildDashboard({ token, childId, apiUrl, onLogout, curre
     if (resp.ok) setWithdrawals(await resp.json())
   }, [apiUrl, token])
 
+  const cancelWithdrawal = async (id: number) => {
+    await fetch(`${apiUrl}/withdrawals/${id}/cancel`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` },
+    })
+    fetchMyWithdrawals()
+  }
+
   const fetchCds = useCallback(async () => {
     const resp = await fetch(`${apiUrl}/cds/child`, {
       headers: { Authorization: `Bearer ${token}` },
@@ -266,12 +274,25 @@ export default function ChildDashboard({ token, childId, apiUrl, onLogout, curre
           <h4>Your Money Requests</h4>
           <p className="help-text">Pending means waiting for a grown-up to decide.</p>
           <ul className="list">
-            {withdrawals.map(w => (
-              <li key={w.id}>
-                {formatCurrency(w.amount, currencySymbol)} - {w.status}
-                {w.denial_reason ? ` (Reason: ${w.denial_reason})` : ''}
-              </li>
-            ))}
+              {withdrawals.map(w => (
+                <li key={w.id}>
+                  {formatCurrency(w.amount, currencySymbol)}{w.memo ? ` (${w.memo})` : ''} - {w.status}
+                  {w.status === 'pending' && (
+                    <button
+                      className="ml-05"
+                      onClick={() =>
+                        setConfirmAction({
+                          message: 'Cancel this request?',
+                          onConfirm: () => cancelWithdrawal(w.id),
+                        })
+                      }
+                    >
+                      Cancel
+                    </button>
+                  )}
+                  {w.denial_reason ? ` (Reason: ${w.denial_reason})` : ''}
+                </li>
+              ))}
           </ul>
         </div>
       )}

--- a/frontend/src/pages/ChildProfile.tsx
+++ b/frontend/src/pages/ChildProfile.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useState } from 'react'
+import { formatCurrency } from '../utils/currency'
 
 interface Props {
   token: string
   apiUrl: string
+  currencySymbol: string
 }
 
 interface ChildProfileData {
@@ -11,15 +13,30 @@ interface ChildProfileData {
   cd_penalty_rate: number
 }
 
-export default function ChildProfile({ token, apiUrl }: Props) {
+interface WithdrawalRequest {
+  id: number
+  child_id: number
+  amount: number
+  memo?: string | null
+  status: string
+  denial_reason?: string | null
+}
+
+export default function ChildProfile({ token, apiUrl, currencySymbol }: Props) {
   const [data, setData] = useState<ChildProfileData | null>(null)
+  const [withdrawals, setWithdrawals] = useState<WithdrawalRequest[]>([])
 
   useEffect(() => {
     const fetchData = async () => {
       const resp = await fetch(`${apiUrl}/children/me`, { headers: { Authorization: `Bearer ${token}` } })
       if (resp.ok) setData((await resp.json()) as ChildProfileData)
     }
+    const fetchWithdrawals = async () => {
+      const resp = await fetch(`${apiUrl}/withdrawals/mine`, { headers: { Authorization: `Bearer ${token}` } })
+      if (resp.ok) setWithdrawals(await resp.json())
+    }
     fetchData()
+    fetchWithdrawals()
   }, [token, apiUrl])
 
   if (!data) return <p>Loading...</p>
@@ -27,9 +44,28 @@ export default function ChildProfile({ token, apiUrl }: Props) {
   return (
     <div className="container">
       <h2>Your Profile</h2>
-      <p>Interest rate: {data.interest_rate}</p>
-      <p>Penalty rate: {data.penalty_interest_rate}</p>
-      <p>CD penalty rate: {data.cd_penalty_rate}</p>
+      <p>
+        Interest rate: {(data.interest_rate * 100).toFixed(2)}% - This is how much extra money you earn for saving.
+      </p>
+      <p>
+        Penalty rate: {(data.penalty_interest_rate * 100).toFixed(2)}% - If your balance goes below zero, you owe this extra.
+      </p>
+      <p>
+        CD penalty rate: {(data.cd_penalty_rate * 100).toFixed(2)}% - Taking money out of a CD early costs this much.
+      </p>
+      {withdrawals.length > 0 && (
+        <div>
+          <h3>Your Money Requests</h3>
+          <ul className="list">
+            {withdrawals.map(w => (
+              <li key={w.id}>
+                {formatCurrency(w.amount, currencySymbol)}{w.memo ? ` (${w.memo})` : ''} - {w.status}
+                {w.denial_reason ? ` (Reason: ${w.denial_reason})` : ''}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
     </div>
   )
 }

--- a/frontend/src/pages/ParentDashboard.tsx
+++ b/frontend/src/pages/ParentDashboard.tsx
@@ -164,12 +164,6 @@ export default function ParentDashboard({
     fetchPendingWithdrawals();
   }, [fetchChildren, fetchPendingWithdrawals]);
 
-  useEffect(() => {
-    if (toast) {
-      const t = setTimeout(() => setToast(null), 3000);
-      return () => clearTimeout(t);
-    }
-  }, [toast]);
 
   const toggleFreeze = async (childId: number, frozen: boolean) => {
     const endpoint = frozen ? "unfreeze" : "freeze";
@@ -183,9 +177,14 @@ export default function ParentDashboard({
   return (
     <div className="container">
       <h2>Your Children</h2>
-      {toast && (
-        <p className={toast.error ? "error" : "success"}>{toast.message}</p>
-      )}
+        {toast && (
+          <div className={toast.error ? "error" : "success"}>
+            <span>{toast.message}</span>
+            <button className="ml-05" onClick={() => setToast(null)}>
+              X
+            </button>
+          </div>
+        )}
       <ul className="list">
         {children.map((c) => (
           <li key={c.id}>
@@ -436,7 +435,7 @@ export default function ParentDashboard({
         <form
           onSubmit={async (e) => {
             e.preventDefault();
-            await fetch(`${apiUrl}/cds`, {
+            const resp = await fetch(`${apiUrl}/cds`, {
               method: "POST",
               headers: {
                 "Content-Type": "application/json",
@@ -449,6 +448,18 @@ export default function ParentDashboard({
                 term_days: Number(cdDays),
               }),
             });
+            if (resp.ok) {
+              alert("CD offer sent!");
+            } else {
+              let msg = "Failed to send CD offer";
+              try {
+                const data = await resp.json();
+                if (data.detail) msg = data.detail;
+              } catch {
+                // ignore
+              }
+              alert(msg);
+            }
             setCdAmount("");
             setCdRate("");
             setCdDays("");


### PR DESCRIPTION
## Summary
- Let children cancel their own pending money requests
- Explain account rates in kid-friendly percentages and show request notes
- Keep parent dashboard toasts until dismissed and alert CD offer results

## Testing
- `python -m app.tests.api_tests`
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688fa752aa6c8323b75310eac77e23d7