### PR TITLE
Run backend tests before starting server

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -4,11 +4,13 @@ WORKDIR /app
 
 # Install dependencies first
 COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt fastapi[all] sqlmodel uvicorn
+RUN pip install --no-cache-dir -r requirements.txt fastapi[all] sqlmodel uvicorn pytest
 
 # Copy application code
 COPY ./app ./app
+COPY ./entrypoint.sh ./entrypoint.sh
+RUN chmod +x entrypoint.sh
 
 ENV PYTHONPATH=/app
 
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["./entrypoint.sh"]

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+
+if [ "$SKIP_TESTS" = "true" ]; then
+  echo "Skipping tests"
+else
+  if [ -d backend/app/tests ]; then
+    pytest backend/app/tests
+  else
+    pytest app/tests
+  fi
+fi
+
+exec uvicorn app.main:app --host 0.0.0.0 --port 8000


### PR DESCRIPTION
## Summary
- add entrypoint script that runs backend tests unless `SKIP_TESTS=true`
- update backend Dockerfile to use entrypoint script and install pytest

## Testing
- `pytest backend/app/tests`

------
https://chatgpt.com/codex/tasks/task_e_688fab6c6d388323b96ba88549209c01