### PR TITLE
Fix CD offer endpoint path

### DIFF
--- a/frontend/src/pages/ParentDashboard.tsx
+++ b/frontend/src/pages/ParentDashboard.tsx
@@ -435,7 +435,7 @@ export default function ParentDashboard({
         <form
           onSubmit={async (e) => {
             e.preventDefault();
-            const resp = await fetch(`${apiUrl}/cds`, {
+            const resp = await fetch(`${apiUrl}/cds/`, {
               method: "POST",
               headers: {
                 "Content-Type": "application/json",


### PR DESCRIPTION
## Summary
- fix CD offer creation path to include trailing slash

## Testing
- `npm run lint`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688fb1b07fec83239e0594b327efb1e5