### PR TITLE
Add parent sharing via one-time share codes

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -9,6 +9,7 @@ definitions.
 from typing import Optional, List
 from datetime import datetime, date
 from sqlmodel import SQLModel, Field, Relationship
+from sqlalchemy import Column, JSON
 
 
 class UserPermissionLink(SQLModel, table=True):
@@ -73,11 +74,26 @@ class Child(SQLModel, table=True):
 
 class ChildUserLink(SQLModel, table=True):
     """Many‑to‑many relationship between parents and children."""
+
     user_id: int = Field(foreign_key="user.id", primary_key=True)
     child_id: int = Field(foreign_key="child.id", primary_key=True)
+    permissions: List[str] = Field(sa_column=Column(JSON), default_factory=list)
+    is_owner: bool = False
 
     user: User = Relationship(back_populates="children")
     child: Child = Relationship(back_populates="parents")
+
+
+class ShareCode(SQLModel, table=True):
+    """One‑time use share code allowing another parent to link a child."""
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    code: str = Field(unique=True, index=True)
+    child_id: int = Field(foreign_key="child.id")
+    created_by: int = Field(foreign_key="user.id")
+    permissions: List[str] = Field(sa_column=Column(JSON), default_factory=list)
+    used_by: Optional[int] = Field(default=None, foreign_key="user.id")
+    created_at: datetime = Field(default_factory=datetime.utcnow)
 
 
 class Account(SQLModel, table=True):

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -37,6 +37,7 @@ from .recurring import (
     RecurringChargeUpdate,
 )
 from .promotion import Promotion
+from .share import ShareCodeCreate, ShareCodeRead, ParentAccess
 
 __all__ = [
     "UserCreate",
@@ -69,4 +70,7 @@ __all__ = [
     "RecurringChargeRead",
     "RecurringChargeUpdate",
     "Promotion",
+    "ShareCodeCreate",
+    "ShareCodeRead",
+    "ParentAccess",
 ]

--- a/backend/app/schemas/share.py
+++ b/backend/app/schemas/share.py
@@ -1,0 +1,22 @@
+"""Schemas for sharing children with other parents."""
+from pydantic import BaseModel
+from typing import List
+
+
+class ShareCodeCreate(BaseModel):
+    permissions: List[str]
+
+
+class ShareCodeRead(BaseModel):
+    code: str
+
+
+class ParentAccess(BaseModel):
+    user_id: int
+    name: str
+    email: str
+    permissions: List[str]
+    is_owner: bool
+
+    class Config:
+        model_config = {"from_attributes": True}

--- a/backend/app/tests/test_sharing.py
+++ b/backend/app/tests/test_sharing.py
@@ -1,0 +1,120 @@
+import asyncio
+import pathlib
+import sys
+
+from httpx import AsyncClient, ASGITransport
+from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
+from sqlmodel import SQLModel, select
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
+
+from app.main import app
+from app.database import get_session
+from app.models import Permission, UserPermissionLink
+from app.crud import ensure_permissions_exist
+from app.acl import ROLE_DEFAULT_PERMISSIONS, ALL_PERMISSIONS
+
+
+async def _setup_test_db():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    TestSession = async_sessionmaker(engine, expire_on_commit=False)
+
+    async def override_get_session():
+        async with TestSession() as session:
+            yield session
+
+    app.dependency_overrides[get_session] = override_get_session
+
+    async with TestSession() as session:
+        await ensure_permissions_exist(session, ALL_PERMISSIONS)
+
+    return TestSession
+
+
+def test_share_and_unshare():
+    async def run():
+        TestSession = await _setup_test_db()
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post(
+                "/register",
+                json={"name": "Parent1", "email": "p1@example.com", "password": "pass"},
+            )
+            p1_id = resp.json()["id"]
+            resp = await client.post(
+                "/register",
+                json={"name": "Parent2", "email": "p2@example.com", "password": "pass"},
+            )
+            p2_id = resp.json()["id"]
+            async with TestSession() as session:
+                for uid in (p1_id, p2_id):
+                    for perm_name in ROLE_DEFAULT_PERMISSIONS["parent"]:
+                        result = await session.execute(
+                            select(Permission).where(Permission.name == perm_name)
+                        )
+                        perm = result.scalar_one()
+                        session.add(
+                            UserPermissionLink(user_id=uid, permission_id=perm.id)
+                        )
+                await session.commit()
+            resp = await client.post(
+                "/login", json={"email": "p1@example.com", "password": "pass"}
+            )
+            headers1 = {"Authorization": f"Bearer {resp.json()['access_token']}"}
+            resp = await client.post(
+                "/login", json={"email": "p2@example.com", "password": "pass"}
+            )
+            headers2 = {"Authorization": f"Bearer {resp.json()['access_token']}"}
+            resp = await client.post(
+                "/children/",
+                headers=headers1,
+                json={"first_name": "Kid", "access_code": "KID"},
+            )
+            child_id = resp.json()["id"]
+            resp = await client.post(
+                f"/children/{child_id}/sharecode",
+                headers=headers1,
+                json={"permissions": ["view_transactions", "deposit"]},
+            )
+            code = resp.json()["code"]
+            resp = await client.post(
+                f"/children/sharecode/{code}", headers=headers2
+            )
+            assert resp.status_code == 200
+            resp = await client.post(
+                "/transactions/",
+                headers=headers2,
+                json={
+                    "child_id": child_id,
+                    "type": "credit",
+                    "amount": 5,
+                    "memo": None,
+                    "initiated_by": "parent",
+                    "initiator_id": 0,
+                },
+            )
+            assert resp.status_code == 200
+            resp = await client.get(
+                f"/children/{child_id}/parents", headers=headers1
+            )
+            assert len(resp.json()) == 2
+            resp = await client.delete(
+                f"/children/{child_id}/parents/{p2_id}", headers=headers1
+            )
+            assert resp.status_code == 204
+            resp = await client.post(
+                "/transactions/",
+                headers=headers2,
+                json={
+                    "child_id": child_id,
+                    "type": "credit",
+                    "amount": 5,
+                    "memo": None,
+                    "initiated_by": "parent",
+                    "initiator_id": 0,
+                },
+            )
+            assert resp.status_code in (403, 404)
+    asyncio.run(run())

--- a/frontend/src/components/ManageAccessModal.tsx
+++ b/frontend/src/components/ManageAccessModal.tsx
@@ -1,0 +1,44 @@
+interface ParentInfo {
+  user_id: number;
+  name: string;
+  email: string;
+  permissions: string[];
+  is_owner: boolean;
+}
+
+interface Props {
+  parents: ParentInfo[];
+  onRemove: (id: number) => void;
+  onClose: () => void;
+}
+
+export default function ManageAccessModal({ parents, onRemove, onClose }: Props) {
+  return (
+    <div className="modal" onClick={onClose}>
+      <div
+        className="modal-content"
+        onClick={(e) => {
+          e.stopPropagation();
+        }}
+      >
+        <h3>Parent Access</h3>
+        <ul className="list">
+          {parents.map((p) => (
+            <li key={p.user_id}>
+              {p.name} ({p.email}) [{p.permissions.join(", ")}]
+              {!p.is_owner && (
+                <button
+                  onClick={() => onRemove(p.user_id)}
+                  className="ml-05"
+                >
+                  Remove
+                </button>
+              )}
+            </li>
+          ))}
+        </ul>
+        <button onClick={onClose}>Close</button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/ShareChildModal.tsx
+++ b/frontend/src/components/ShareChildModal.tsx
@@ -1,0 +1,55 @@
+import { useState } from "react";
+
+interface Props {
+  onSubmit: (perms: string[]) => void;
+  onCancel: () => void;
+}
+
+const PERMISSIONS = [
+  "view_transactions",
+  "deposit",
+  "debit",
+  "freeze_child",
+];
+
+export default function ShareChildModal({ onSubmit, onCancel }: Props) {
+  const [selected, setSelected] = useState<string[]>([]);
+  return (
+    <div className="modal" onClick={onCancel}>
+      <div
+        className="modal-content"
+        onClick={(e) => {
+          e.stopPropagation();
+        }}
+      >
+        <h3>Select Permissions</h3>
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            onSubmit(selected);
+          }}
+        >
+          {PERMISSIONS.map((p) => (
+            <label key={p} className="block">
+              <input
+                type="checkbox"
+                checked={selected.includes(p)}
+                onChange={(e) => {
+                  if (e.target.checked) setSelected([...selected, p]);
+                  else setSelected(selected.filter((x) => x !== p));
+                }}
+              />
+              {p}
+            </label>
+          ))}
+          <div className="mt-1">
+            <button type="submit">Generate</button>
+            <button type="button" onClick={onCancel} className="ml-05">
+              Cancel
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- allow primary parents to generate one-time share codes with selected permissions
- enable secondary parents to redeem codes and link to a child
- provide UI to generate/redeem codes and manage shared access

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688fbdc9ec308323a88a5d3aaefede61