### PR TITLE
Add basic loan system

### DIFF
--- a/backend/app/acl.py
+++ b/backend/app/acl.py
@@ -19,6 +19,8 @@ PERM_ADD_RECURRING = "add_recurring_charge"
 PERM_EDIT_RECURRING = "edit_recurring_charge"
 PERM_DELETE_RECURRING = "delete_recurring_charge"
 PERM_OFFER_CD = "offer_cd"
+PERM_OFFER_LOAN = "offer_loan"
+PERM_MANAGE_LOAN = "manage_loan"
 
 ALL_PERMISSIONS = [
     PERM_ADD_TRANSACTION,
@@ -34,6 +36,8 @@ ALL_PERMISSIONS = [
     PERM_EDIT_RECURRING,
     PERM_DELETE_RECURRING,
     PERM_OFFER_CD,
+    PERM_OFFER_LOAN,
+    PERM_MANAGE_LOAN,
 ]
 
 ROLE_DEFAULT_PERMISSIONS = {
@@ -51,6 +55,8 @@ ROLE_DEFAULT_PERMISSIONS = {
         PERM_EDIT_RECURRING,
         PERM_DELETE_RECURRING,
         PERM_OFFER_CD,
+        PERM_OFFER_LOAN,
+        PERM_MANAGE_LOAN,
     ],
     "child": [PERM_VIEW_TRANSACTIONS],
 }

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -24,6 +24,7 @@ from app.routes import (
     cds,
     settings,
     recurring,
+    loans,
 )
 from app.database import create_db_and_tables, async_session
 from app.crud import (
@@ -34,6 +35,7 @@ from app.crud import (
     get_settings,
     apply_service_fee,
     apply_overdraft_fee,
+    process_loan_interest,
 )
 from app.models import Child
 from app.acl import ALL_PERMISSIONS
@@ -112,6 +114,7 @@ async def daily_interest_task():
                 for account in accounts:
                     await apply_service_fee(session, account, settings, today)
                     await apply_overdraft_fee(session, account, settings, today)
+                await process_loan_interest(session)
                 from app.crud import redeem_matured_cds
 
                 # Finally, redeem any matured certificates of deposit.
@@ -132,6 +135,7 @@ app.include_router(admin.router)
 app.include_router(tests.router)
 app.include_router(settings.router)
 app.include_router(recurring.router)
+app.include_router(loans.router)
 
 
 @app.get("/docs", include_in_schema=False)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -178,6 +178,38 @@ class CertificateDeposit(SQLModel, table=True):
     parent: User = Relationship()
 
 
+class Loan(SQLModel, table=True):
+    """Simple loan offered by a parent to a child."""
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    child_id: int = Field(foreign_key="child.id")
+    parent_id: Optional[int] = Field(default=None, foreign_key="user.id")
+    amount: float
+    purpose: Optional[str] = None
+    interest_rate: float = 0.0
+    status: str = "requested"  # requested, approved, active, denied, closed
+    principal_remaining: float = 0.0
+    last_interest_applied: Optional[date] = None
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+
+    child: Child = Relationship()
+    parent: Optional[User] = Relationship()
+    transactions: List["LoanTransaction"] = Relationship(back_populates="loan")
+
+
+class LoanTransaction(SQLModel, table=True):
+    """Ledger of loan-related transactions."""
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    loan_id: int = Field(foreign_key="loan.id")
+    type: str  # disbursement, payment, interest, fee
+    amount: float
+    memo: Optional[str] = None
+    timestamp: datetime = Field(default_factory=datetime.utcnow)
+
+    loan: Loan = Relationship(back_populates="transactions")
+
+
 class Settings(SQLModel, table=True):
     """Singleton table storing site‑wide configuration values."""
     id: Optional[int] = Field(default=1, primary_key=True)

--- a/backend/app/routes/__init__.py
+++ b/backend/app/routes/__init__.py
@@ -1,6 +1,18 @@
 """Aggregate import for all API route modules."""
 
-from . import auth, users, children, transactions, withdrawals, admin, tests, cds, settings, recurring
+from . import (
+    auth,
+    users,
+    children,
+    transactions,
+    withdrawals,
+    admin,
+    tests,
+    cds,
+    settings,
+    recurring,
+    loans,
+)
 
 __all__ = [
     "auth",
@@ -13,4 +25,5 @@ __all__ = [
     "admin",
     "tests",
     "recurring",
+    "loans",
 ]

--- a/backend/app/routes/loans.py
+++ b/backend/app/routes/loans.py
@@ -1,0 +1,178 @@
+from datetime import date
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_session
+from app.models import Loan, LoanTransaction, Child, User, Transaction
+from app.schemas import LoanCreate, LoanRead, LoanApprove, LoanPayment
+from app.auth import get_current_child, require_permissions
+from app.acl import PERM_OFFER_LOAN, PERM_MANAGE_LOAN
+from app.crud import (
+    create_loan,
+    get_loan,
+    save_loan,
+    get_loans_by_child,
+    record_loan_transaction,
+    get_child_user_link,
+    create_transaction,
+    post_transaction_update,
+)
+
+router = APIRouter(prefix="/loans", tags=["loans"])
+
+
+@router.post("/", response_model=LoanRead)
+async def request_loan(
+    data: LoanCreate,
+    child: Child = Depends(get_current_child),
+    db: AsyncSession = Depends(get_session),
+):
+    loan = Loan(child_id=child.id, amount=data.amount, purpose=data.purpose)
+    return await create_loan(db, loan)
+
+
+@router.get("/child", response_model=list[LoanRead])
+async def my_loans(
+    child: Child = Depends(get_current_child),
+    db: AsyncSession = Depends(get_session),
+):
+    return await get_loans_by_child(db, child.id)
+
+
+@router.post("/{loan_id}/accept", response_model=LoanRead)
+async def accept_loan(
+    loan_id: int,
+    child: Child = Depends(get_current_child),
+    db: AsyncSession = Depends(get_session),
+):
+    loan = await get_loan(db, loan_id)
+    if not loan or loan.child_id != child.id:
+        raise HTTPException(status_code=404, detail="Loan not found")
+    if loan.status != "approved":
+        raise HTTPException(status_code=400, detail="Cannot accept")
+    await create_transaction(
+        db,
+        Transaction(
+            child_id=child.id,
+            type="credit",
+            amount=loan.amount,
+            memo=f"Loan #{loan.id} disbursement",
+            initiated_by="child",
+            initiator_id=child.id,
+        ),
+    )
+    await post_transaction_update(db, child.id)
+    await record_loan_transaction(
+        db,
+        LoanTransaction(
+            loan_id=loan.id,
+            type="disbursement",
+            amount=loan.amount,
+            memo="Loan disbursement",
+        ),
+    )
+    loan.status = "active"
+    loan.last_interest_applied = date.today()
+    loan.principal_remaining = loan.amount
+    await save_loan(db, loan)
+    return loan
+
+
+@router.post("/{loan_id}/approve", response_model=LoanRead)
+async def approve_loan_route(
+    loan_id: int,
+    data: LoanApprove,
+    db: AsyncSession = Depends(get_session),
+    current_user: User = Depends(require_permissions(PERM_OFFER_LOAN)),
+):
+    loan = await get_loan(db, loan_id)
+    if not loan:
+        raise HTTPException(status_code=404, detail="Loan not found")
+    if current_user.role != "admin":
+        link = await get_child_user_link(db, current_user.id, loan.child_id)
+        if not link or (PERM_OFFER_LOAN not in link.permissions and not link.is_owner):
+            raise HTTPException(status_code=403, detail="Insufficient permissions")
+    loan.status = "approved"
+    loan.parent_id = current_user.id
+    loan.interest_rate = data.interest_rate
+    loan.principal_remaining = loan.amount
+    await save_loan(db, loan)
+    return loan
+
+
+@router.post("/{loan_id}/deny", response_model=LoanRead)
+async def deny_loan_route(
+    loan_id: int,
+    db: AsyncSession = Depends(get_session),
+    current_user: User = Depends(require_permissions(PERM_OFFER_LOAN)),
+):
+    loan = await get_loan(db, loan_id)
+    if not loan:
+        raise HTTPException(status_code=404, detail="Loan not found")
+    if current_user.role != "admin":
+        link = await get_child_user_link(db, current_user.id, loan.child_id)
+        if not link or (PERM_OFFER_LOAN not in link.permissions and not link.is_owner):
+            raise HTTPException(status_code=403, detail="Insufficient permissions")
+    loan.status = "denied"
+    loan.parent_id = current_user.id
+    await save_loan(db, loan)
+    return loan
+
+
+@router.get("/child/{child_id}", response_model=list[LoanRead])
+async def parent_loans(
+    child_id: int,
+    db: AsyncSession = Depends(get_session),
+    current_user: User = Depends(require_permissions(PERM_MANAGE_LOAN)),
+):
+    if current_user.role != "admin":
+        link = await get_child_user_link(db, current_user.id, child_id)
+        if not link or (
+            PERM_MANAGE_LOAN not in link.permissions
+            and PERM_OFFER_LOAN not in link.permissions
+            and not link.is_owner
+        ):
+            raise HTTPException(status_code=403, detail="Insufficient permissions")
+    return await get_loans_by_child(db, child_id)
+
+
+@router.post("/{loan_id}/payment", response_model=LoanRead)
+async def record_payment(
+    loan_id: int,
+    data: LoanPayment,
+    db: AsyncSession = Depends(get_session),
+    current_user: User = Depends(require_permissions(PERM_MANAGE_LOAN)),
+):
+    loan = await get_loan(db, loan_id)
+    if not loan:
+        raise HTTPException(status_code=404, detail="Loan not found")
+    if current_user.role != "admin":
+        link = await get_child_user_link(db, current_user.id, loan.child_id)
+        if not link or (PERM_MANAGE_LOAN not in link.permissions and not link.is_owner):
+            raise HTTPException(status_code=403, detail="Insufficient permissions")
+    await create_transaction(
+        db,
+        Transaction(
+            child_id=loan.child_id,
+            type="debit",
+            amount=data.amount,
+            memo=f"Loan #{loan.id} payment",
+            initiated_by="parent",
+            initiator_id=current_user.id,
+        ),
+    )
+    await post_transaction_update(db, loan.child_id)
+    await record_loan_transaction(
+        db,
+        LoanTransaction(
+            loan_id=loan.id,
+            type="payment",
+            amount=data.amount,
+            memo="Payment",
+        ),
+    )
+    loan.principal_remaining = round(loan.principal_remaining - data.amount, 2)
+    if loan.principal_remaining <= 0:
+        loan.status = "closed"
+    await save_loan(db, loan)
+    return loan

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -38,6 +38,7 @@ from .recurring import (
 )
 from .promotion import Promotion
 from .share import ShareCodeCreate, ShareCodeRead, ParentAccess
+from .loan import LoanCreate, LoanRead, LoanApprove, LoanPayment
 
 __all__ = [
     "UserCreate",
@@ -73,4 +74,8 @@ __all__ = [
     "ShareCodeCreate",
     "ShareCodeRead",
     "ParentAccess",
+    "LoanCreate",
+    "LoanRead",
+    "LoanApprove",
+    "LoanPayment",
 ]

--- a/backend/app/schemas/loan.py
+++ b/backend/app/schemas/loan.py
@@ -1,0 +1,32 @@
+from datetime import datetime
+from pydantic import BaseModel
+from typing import Optional
+
+
+class LoanCreate(BaseModel):
+    child_id: int
+    amount: float
+    purpose: Optional[str] = None
+
+
+class LoanRead(BaseModel):
+    id: int
+    child_id: int
+    parent_id: Optional[int]
+    amount: float
+    purpose: Optional[str]
+    interest_rate: float
+    status: str
+    principal_remaining: float
+    created_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+class LoanApprove(BaseModel):
+    interest_rate: float
+
+
+class LoanPayment(BaseModel):
+    amount: float

--- a/backend/app/tests/test_loans.py
+++ b/backend/app/tests/test_loans.py
@@ -1,0 +1,157 @@
+import asyncio
+import pathlib
+import sys
+
+from httpx import AsyncClient, ASGITransport
+from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
+from sqlmodel import SQLModel, select
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
+
+from app.main import app
+from app.database import get_session
+from app.models import Permission, UserPermissionLink, User, ChildUserLink
+from app.auth import get_password_hash
+from app.crud import ensure_permissions_exist
+from app.acl import ROLE_DEFAULT_PERMISSIONS, ALL_PERMISSIONS, PERM_OFFER_LOAN, PERM_MANAGE_LOAN
+
+
+async def _setup_test_db():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    TestSession = async_sessionmaker(engine, expire_on_commit=False)
+
+    async def override_get_session():
+        async with TestSession() as session:
+            yield session
+
+    app.dependency_overrides[get_session] = override_get_session
+
+    async with TestSession() as session:
+        await ensure_permissions_exist(session, ALL_PERMISSIONS)
+        admin = User(
+            name="Admin",
+            email="admin@example.com",
+            password_hash=get_password_hash("adminpass"),
+            role="admin",
+        )
+        session.add(admin)
+        await session.commit()
+
+    return TestSession
+
+
+def test_loan_flow():
+    async def run():
+        TestSession = await _setup_test_db()
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post(
+                "/login", json={"email": "admin@example.com", "password": "adminpass"}
+            )
+            assert resp.status_code == 200
+            admin_headers = {"Authorization": f"Bearer {resp.json()['access_token']}"}
+
+            # Register parent1 and parent2
+            resp = await client.post(
+                "/register",
+                json={"name": "Parent1", "email": "p1@example.com", "password": "pass"},
+            )
+            parent1_id = resp.json()["id"]
+            resp = await client.post(
+                "/register",
+                json={"name": "Parent2", "email": "p2@example.com", "password": "pass"},
+            )
+            parent2_id = resp.json()["id"]
+
+            # Grant default permissions to parent1 only
+            async with TestSession() as session:
+                for perm_name in ROLE_DEFAULT_PERMISSIONS["parent"]:
+                    result = await session.execute(
+                        select(Permission).where(Permission.name == perm_name)
+                    )
+                    perm = result.scalar_one()
+                    session.add(UserPermissionLink(user_id=parent1_id, permission_id=perm.id))
+                await session.commit()
+
+            # Parent1 login
+            resp = await client.post(
+                "/login", json={"email": "p1@example.com", "password": "pass"}
+            )
+            parent1_headers = {"Authorization": f"Bearer {resp.json()['access_token']}"}
+
+            # Parent2 login
+            resp = await client.post(
+                "/login", json={"email": "p2@example.com", "password": "pass"}
+            )
+            parent2_headers = {"Authorization": f"Bearer {resp.json()['access_token']}"}
+
+            # Create child
+            resp = await client.post(
+                "/children/",
+                headers=parent1_headers,
+                json={"first_name": "Kid", "access_code": "KID"},
+            )
+            child_id = resp.json()["id"]
+
+            # Link parent2 to child without loan permissions
+            async with TestSession() as session:
+                link = ChildUserLink(user_id=parent2_id, child_id=child_id, permissions=[])
+                session.add(link)
+                await session.commit()
+
+            # Child login
+            resp = await client.post("/children/login", json={"access_code": "KID"})
+            child_headers = {"Authorization": f"Bearer {resp.json()['access_token']}"}
+
+            # Child requests loan
+            resp = await client.post(
+                "/loans/",
+                headers=child_headers,
+                json={"child_id": child_id, "amount": 50, "purpose": "Bike"},
+            )
+            loan_id = resp.json()["id"]
+
+            # Parent2 tries to approve loan -> 403
+            resp = await client.post(
+                f"/loans/{loan_id}/approve",
+                headers=parent2_headers,
+                json={"interest_rate": 0.01},
+            )
+            assert resp.status_code == 403
+
+            # Parent1 approves loan
+            resp = await client.post(
+                f"/loans/{loan_id}/approve",
+                headers=parent1_headers,
+                json={"interest_rate": 0.01},
+            )
+            assert resp.status_code == 200
+
+            # Child accepts loan
+            resp = await client.post(
+                f"/loans/{loan_id}/accept", headers=child_headers
+            )
+            assert resp.status_code == 200
+            assert resp.json()["status"] == "active"
+            assert resp.json()["principal_remaining"] == 50
+
+            # Parent2 payment attempt -> 403
+            resp = await client.post(
+                f"/loans/{loan_id}/payment",
+                headers=parent2_headers,
+                json={"amount": 10},
+            )
+            assert resp.status_code == 403
+
+            # Parent1 records payment
+            resp = await client.post(
+                f"/loans/{loan_id}/payment",
+                headers=parent1_headers,
+                json={"amount": 20},
+            )
+            assert resp.status_code == 200
+            assert resp.json()["principal_remaining"] == 30
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- introduce loan permissions and models
- add endpoints for children to request loans and for parents to approve/pay them
- process loan interest daily and cover with tests

## Testing
- `pytest app/tests/test_loans.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688fd92cba448323a7082b5fb6573f2f