### PR TITLE
Use percentage notation and streamline dashboards

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -93,6 +93,19 @@
   overflow-x: auto;
 }
 
+.ledger-area {
+  border: 1px solid var(--container-border, #ccc);
+  border-radius: 4px;
+  padding: 1rem;
+  margin-top: 1rem;
+}
+
+.ledger-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
 .ml-1 {
   color: white;
   margin-left: 1em;

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -65,30 +65,24 @@
   border: 1px solid var(--container-border, #ccc);
   border-radius: 4px;
   margin-bottom: 0.5rem;
+}
+.child-card summary {
   padding: 0.5rem;
-  display: flex;
-  flex-direction: column;
+  cursor: pointer;
 }
 .child-actions {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
-  margin-top: 0.5rem;
+  padding: 0.5rem;
 }
 .child-actions button {
   width: 100%;
 }
 @media (min-width: 600px) {
-  .child-card {
-    flex-direction: row;
-    justify-content: space-between;
-    align-items: center;
-  }
   .child-actions {
     flex-direction: row;
     flex-wrap: wrap;
-    margin-top: 0;
-    justify-content: flex-end;
   }
   .child-actions button {
     flex: 1 0 45%;

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -65,24 +65,30 @@
   border: 1px solid var(--container-border, #ccc);
   border-radius: 4px;
   margin-bottom: 0.5rem;
-}
-.child-card summary {
   padding: 0.5rem;
-  cursor: pointer;
+  display: flex;
+  flex-direction: column;
 }
 .child-actions {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
-  padding: 0.5rem;
+  margin-top: 0.5rem;
 }
 .child-actions button {
   width: 100%;
 }
 @media (min-width: 600px) {
+  .child-card {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+  }
   .child-actions {
     flex-direction: row;
     flex-wrap: wrap;
+    margin-top: 0;
+    justify-content: flex-end;
   }
   .child-actions button {
     flex: 1 0 45%;

--- a/frontend/src/components/EditSiteSettingsModal.tsx
+++ b/frontend/src/components/EditSiteSettingsModal.tsx
@@ -24,9 +24,9 @@ interface Props {
 export default function EditSiteSettingsModal({ settings, token, apiUrl, onClose, onSaved }: Props) {
   const [form, setForm] = useState({
     site_name: settings.site_name,
-    default_interest_rate: settings.default_interest_rate.toString(),
-    default_penalty_interest_rate: settings.default_penalty_interest_rate.toString(),
-    default_cd_penalty_rate: settings.default_cd_penalty_rate.toString(),
+    default_interest_rate: (settings.default_interest_rate * 100).toString(),
+    default_penalty_interest_rate: (settings.default_penalty_interest_rate * 100).toString(),
+    default_cd_penalty_rate: (settings.default_cd_penalty_rate * 100).toString(),
     service_fee_amount: settings.service_fee_amount.toString(),
     service_fee_is_percentage: settings.service_fee_is_percentage,
     overdraft_fee_amount: settings.overdraft_fee_amount.toString(),
@@ -47,9 +47,9 @@ export default function EditSiteSettingsModal({ settings, token, apiUrl, onClose
       headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
       body: JSON.stringify({
         site_name: form.site_name,
-        default_interest_rate: Number(form.default_interest_rate),
-        default_penalty_interest_rate: Number(form.default_penalty_interest_rate),
-        default_cd_penalty_rate: Number(form.default_cd_penalty_rate),
+        default_interest_rate: Number(form.default_interest_rate) / 100,
+        default_penalty_interest_rate: Number(form.default_penalty_interest_rate) / 100,
+        default_cd_penalty_rate: Number(form.default_cd_penalty_rate) / 100,
         service_fee_amount: Number(form.service_fee_amount),
         service_fee_is_percentage: form.service_fee_is_percentage,
         overdraft_fee_amount: Number(form.overdraft_fee_amount),
@@ -76,16 +76,16 @@ export default function EditSiteSettingsModal({ settings, token, apiUrl, onClose
             <input name="currency_symbol" value={form.currency_symbol} onChange={handleChange} required />
           </label>
           <label>
-            Default Interest Rate
-            <input name="default_interest_rate" type="number" step="0.0001" value={form.default_interest_rate} onChange={handleChange} required />
+            Default Interest Rate (%)
+            <input name="default_interest_rate" type="number" step="0.01" value={form.default_interest_rate} onChange={handleChange} required />
           </label>
           <label>
-            Penalty Interest Rate
-            <input name="default_penalty_interest_rate" type="number" step="0.0001" value={form.default_penalty_interest_rate} onChange={handleChange} required />
+            Penalty Interest Rate (%)
+            <input name="default_penalty_interest_rate" type="number" step="0.01" value={form.default_penalty_interest_rate} onChange={handleChange} required />
           </label>
           <label>
-            CD Penalty Rate
-            <input name="default_cd_penalty_rate" type="number" step="0.0001" value={form.default_cd_penalty_rate} onChange={handleChange} required />
+            CD Penalty Rate (%)
+            <input name="default_cd_penalty_rate" type="number" step="0.01" value={form.default_cd_penalty_rate} onChange={handleChange} required />
           </label>
           <label>
             Service Fee Amount

--- a/frontend/src/components/Header.css
+++ b/frontend/src/components/Header.css
@@ -16,6 +16,11 @@
   color: var(--text-color);
   text-decoration: none;
 }
+
+.header a.active {
+  text-decoration: underline;
+  font-weight: bold;
+}
 .header button {
   background: var(--button-bg);
   color: white;

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router-dom'
+import { NavLink } from 'react-router-dom'
 import './Header.css'
 
 interface Props {
@@ -18,18 +18,18 @@ export default function Header({ onLogout, isAdmin, isChild, siteName, onToggleT
         <ul>
           {isChild ? (
               <>
-                <li><Link to="/child">Ledger</Link></li>
-                <li><Link to="/child/loans">Loans</Link></li>
-                <li><Link to="/child/profile">Profile</Link></li>
+                <li><NavLink to="/child" className={({isActive}) => isActive ? 'active' : undefined}>Ledger</NavLink></li>
+                <li><NavLink to="/child/loans" className={({isActive}) => isActive ? 'active' : undefined}>Loans</NavLink></li>
+                <li><NavLink to="/child/profile" className={({isActive}) => isActive ? 'active' : undefined}>Profile</NavLink></li>
               </>
             ) : (
               <>
-                <li><Link to="/">Dashboard</Link></li>
-                <li><Link to="/parent/loans">Loans</Link></li>
-                <li><Link to="/parent/profile">Profile</Link></li>
+                <li><NavLink to="/" className={({isActive}) => isActive ? 'active' : undefined}>Dashboard</NavLink></li>
+                <li><NavLink to="/parent/loans" className={({isActive}) => isActive ? 'active' : undefined}>Loans</NavLink></li>
+                <li><NavLink to="/parent/profile" className={({isActive}) => isActive ? 'active' : undefined}>Profile</NavLink></li>
               </>
             )}
-          {isAdmin && <li><Link to="/admin">Admin</Link></li>}
+          {isAdmin && <li><NavLink to="/admin" className={({isActive}) => isActive ? 'active' : undefined}>Admin</NavLink></li>}
           <li><button onClick={onToggleTheme}>{theme === 'dark' ? 'Light Mode' : 'Dark Mode'}</button></li>
           <li><button onClick={onLogout}>Logout</button></li>
         </ul>

--- a/frontend/src/components/RunPromotionModal.tsx
+++ b/frontend/src/components/RunPromotionModal.tsx
@@ -19,7 +19,7 @@ export default function RunPromotionModal({ token, apiUrl, onClose, onSaved }: P
       method: 'POST',
       headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
       body: JSON.stringify({
-        amount: Number(amount),
+        amount: isPct ? Number(amount) / 100 : Number(amount),
         is_percentage: isPct,
         credit,
         memo,
@@ -35,8 +35,8 @@ export default function RunPromotionModal({ token, apiUrl, onClose, onSaved }: P
         <h3>Run Promotion</h3>
         <form onSubmit={handleSubmit} className="form">
           <label>
-            Amount or Percentage
-            <input type="number" step="0.01" value={amount} onChange={e => setAmount(e.target.value)} required />
+            Amount or Percentage {isPct ? '(%)' : ''}
+            <input type="number" step="0.01" value={amount} onChange={e => setAmount(e.target.value)} required />{isPct && '%'}
           </label>
           <label>
             <input type="checkbox" checked={isPct} onChange={e => setIsPct(e.target.checked)} /> Percentage?

--- a/frontend/src/pages/AdminPanel.tsx
+++ b/frontend/src/pages/AdminPanel.tsx
@@ -94,9 +94,9 @@ export default function AdminPanel({ token, apiUrl, onLogout, siteName, currency
         <div>
           <h2>Site Settings</h2>
           <p>Name: {settings.site_name}</p>
-          <p>Default Interest Rate: {settings.default_interest_rate}</p>
-          <p>Penalty Interest Rate: {settings.default_penalty_interest_rate}</p>
-          <p>CD Penalty Rate: {settings.default_cd_penalty_rate}</p>
+          <p>Default Interest Rate: {(settings.default_interest_rate * 100).toFixed(2)}%</p>
+          <p>Penalty Interest Rate: {(settings.default_penalty_interest_rate * 100).toFixed(2)}%</p>
+          <p>CD Penalty Rate: {(settings.default_cd_penalty_rate * 100).toFixed(2)}%</p>
           <p>Currency Symbol: {settings.currency_symbol}</p>
           <p>
             Service Fee: {settings.service_fee_is_percentage ? `${settings.service_fee_amount}%` : formatCurrency(settings.service_fee_amount, currencySymbol)}

--- a/frontend/src/pages/ParentDashboard.tsx
+++ b/frontend/src/pages/ParentDashboard.tsx
@@ -126,6 +126,12 @@ export default function ParentDashboard({
   const [rcInterval, setRcInterval] = useState("");
   const [rcNext, setRcNext] = useState("");
 
+  const closeLedger = () => {
+    setLedger(null);
+    setSelectedChild(null);
+    setCharges([]);
+  };
+
   const fetchChildren = useCallback(async () => {
     const resp = await fetch(`${apiUrl}/children/`, {
       headers: { Authorization: `Bearer ${token}` },
@@ -229,7 +235,14 @@ export default function ParentDashboard({
                 {c.first_name} {c.frozen && "(Frozen)"}
               </summary>
               <div className="child-actions">
-                <button onClick={() => setActionChild(c)}>Actions</button>
+                <button
+                  onClick={() => {
+                    closeLedger();
+                    setActionChild(c);
+                  }}
+                >
+                  Actions
+                </button>
               </div>
             </details>
           </li>
@@ -250,6 +263,7 @@ export default function ParentDashboard({
             <div className="child-actions">
               <button
                 onClick={() => {
+                  closeLedger();
                   setEditingChild(actionChild);
                   setActionChild(null);
                 }}
@@ -258,6 +272,7 @@ export default function ParentDashboard({
               </button>
               <button
                 onClick={() => {
+                  closeLedger();
                   toggleFreeze(actionChild.id, actionChild.frozen);
                   setActionChild(null);
                 }}
@@ -266,6 +281,7 @@ export default function ParentDashboard({
               </button>
               <button
                 onClick={() => {
+                  closeLedger();
                   setCodeChild(actionChild);
                   setActionChild(null);
                 }}
@@ -274,6 +290,7 @@ export default function ParentDashboard({
               </button>
               <button
                 onClick={() => {
+                  closeLedger();
                   setSharingChild(actionChild);
                   setActionChild(null);
                 }}
@@ -282,6 +299,7 @@ export default function ParentDashboard({
               </button>
               <button
                 onClick={() => {
+                  closeLedger();
                   openAccess(actionChild);
                   setActionChild(null);
                 }}
@@ -290,6 +308,7 @@ export default function ParentDashboard({
               </button>
               <button
                 onClick={() => {
+                  closeLedger();
                   fetchLedger(actionChild.id);
                   fetchCharges(actionChild.id);
                   setSelectedChild(actionChild.id);
@@ -308,8 +327,11 @@ export default function ParentDashboard({
         </div>
       )}
       {ledger && selectedChild !== null && (
-        <div>
-          <h4>Ledger for child #{selectedChild}</h4>
+        <div className="ledger-area">
+          <div className="ledger-header">
+            <h4>Ledger for child #{selectedChild}</h4>
+            <button onClick={closeLedger}>Close Ledger</button>
+          </div>
           <p>Balance: {formatCurrency(ledger.balance, currencySymbol)}</p>
           <div className="ledger-scroll">
             <LedgerTable

--- a/frontend/src/pages/ParentDashboard.tsx
+++ b/frontend/src/pages/ParentDashboard.tsx
@@ -112,6 +112,7 @@ export default function ParentDashboard({
   const [redeemOpen, setRedeemOpen] = useState(false);
   const [accessChild, setAccessChild] = useState<Child | null>(null);
   const [accessParents, setAccessParents] = useState<ParentInfo[]>([]);
+  const [childTab, setChildTab] = useState<'ledger' | 'actions'>('ledger');
   const [editingCharge, setEditingCharge] = useState<RecurringCharge | null>(null);
   const [toast, setToast] = useState<{ message: string; error?: boolean } | null>(null);
   const canEdit = permissions.includes("edit_transaction");
@@ -222,43 +223,50 @@ export default function ParentDashboard({
         )}
       <ul className="list">
         {children.map((c) => (
-          <li key={c.id}>
-            <details className="child-card">
-              <summary>
-                {c.first_name} {c.frozen && "(Frozen)"}
-              </summary>
-              <div className="child-actions">
-                <button onClick={() => setEditingChild(c)}>Rates</button>
-                <button onClick={() => toggleFreeze(c.id, c.frozen)}>
-                  {c.frozen ? "Unfreeze" : "Freeze"}
-                </button>
-                <button onClick={() => setCodeChild(c)}>Change Code</button>
-                <button onClick={() => setSharingChild(c)}>Share</button>
-                <button onClick={() => openAccess(c)}>Manage Access</button>
-                <button
-                  onClick={() => {
-                    fetchLedger(c.id);
-                    fetchCharges(c.id);
-                    setSelectedChild(c.id);
-                  }}
-                >
-                  View Ledger
-                </button>
-              </div>
-            </details>
+          <li key={c.id} className="child-card">
+            <span>{c.first_name} {c.frozen && "(Frozen)"}</span>
+            <div className="child-actions">
+              <button onClick={() => setEditingChild(c)}>Rates</button>
+              <button onClick={() => toggleFreeze(c.id, c.frozen)}>
+                {c.frozen ? "Unfreeze" : "Freeze"}
+              </button>
+              <button onClick={() => setCodeChild(c)}>Change Code</button>
+              <button onClick={() => setSharingChild(c)}>Share</button>
+              <button onClick={() => openAccess(c)}>Manage Access</button>
+              <button
+                onClick={() => {
+                  fetchLedger(c.id);
+                  fetchCharges(c.id);
+                  setSelectedChild(c.id);
+                  setChildTab('ledger');
+                }}
+              >
+                Ledger
+              </button>
+              <button
+                onClick={() => {
+                  setSelectedChild(c.id);
+                  setChildTab('actions');
+                }}
+              >
+                Actions
+              </button>
+            </div>
           </li>
         ))}
       </ul>
-      {ledger && selectedChild !== null && (
+      {selectedChild !== null && (
         <div>
-          <h4>Ledger for child #{selectedChild}</h4>
-          <p>Balance: {formatCurrency(ledger.balance, currencySymbol)}</p>
-          <div className="ledger-scroll">
-            <LedgerTable
-              transactions={ledger.transactions}
-              allowDownload
-              currencySymbol={currencySymbol}
-              renderActions={(tx) => (
+          <h4>Child #{selectedChild}</h4>
+          {childTab === 'ledger' && ledger && (
+            <>
+              <p>Balance: {formatCurrency(ledger.balance, currencySymbol)}</p>
+              <div className="ledger-scroll">
+                <LedgerTable
+                  transactions={ledger.transactions}
+                  allowDownload
+                  currencySymbol={currencySymbol}
+                  renderActions={(tx) => (
               <>
                 {canEdit && tx.initiated_by !== "system" && (
                   <button
@@ -332,225 +340,231 @@ export default function ParentDashboard({
               </li>
             ))}
           </ul>
-          {canAddRecurring && (
-            <form
-            onSubmit={async (e) => {
-              e.preventDefault();
-                const nextDate = new Date(rcNext + "T00:00:00");
-                const today = new Date();
-                today.setHours(0, 0, 0, 0);
-                if (nextDate < today) {
-                  setToast({ message: "Next run cannot be in the past", error: true });
-                  return;
-                }
-                const resp = await fetch(`${apiUrl}/recurring/child/${selectedChild}`, {
-                  method: "POST",
-                  headers: {
-                    "Content-Type": "application/json",
-                    Authorization: `Bearer ${token}`,
-                  },
-                  body: JSON.stringify({
-                    amount: Number(rcAmount),
-                    memo: rcMemo || null,
-                    interval_days: Number(rcInterval),
-                    next_run: rcNext,
-                    type: rcType,
-                  }),
-                });
-                if (!resp.ok) {
-                  const data = await resp.json().catch(() => null);
-                  setToast({
-                    message: data?.detail || "Action failed",
-                    error: true,
-                  });
-                  return;
-                }
-                setRcAmount("");
-                setRcType("debit");
-                setRcMemo("");
-                setRcInterval("");
-                setRcNext("");
-                fetchCharges(selectedChild);
-              }}
-              className="form"
-            >
-              <h4>Add Recurring Transaction</h4>
-              <label>
-                Type
-                <select value={rcType} onChange={(e) => setRcType(e.target.value)}>
-                  <option value="debit">Debit</option>
-                  <option value="credit">Credit</option>
-                </select>
-              </label>
-              <label>
-                Amount
-                <input
-                  type="number"
-                  step="0.01"
-                  value={rcAmount}
-                  onChange={(e) => setRcAmount(e.target.value)}
-                  required
-                />
-              </label>
-              <label>
-                Memo
-                <input
-                  value={rcMemo}
-                  onChange={(e) => setRcMemo(e.target.value)}
-                />
-              </label>
-              <label>
-                Interval days
-                <input
-                  type="number"
-                  value={rcInterval}
-                  onChange={(e) => setRcInterval(e.target.value)}
-                  required
-                />
-              </label>
-              <label>
-                Next run
-                <input
-                  type="date"
-                  value={rcNext}
-                  onChange={(e) => setRcNext(e.target.value)}
-                  required
-                />
-              </label>
-              <button type="submit">Add</button>
-            </form>
+            </>
           )}
-          <form
-            onSubmit={async (e) => {
-              e.preventDefault();
-              const resp = await fetch(`${apiUrl}/transactions/`, {
-                method: "POST",
-                headers: {
-                  "Content-Type": "application/json",
-                  Authorization: `Bearer ${token}`,
-                },
-                body: JSON.stringify({
-                  child_id: selectedChild,
-                  type: txType,
-                  amount: Number(txAmount),
-                  memo: txMemo || null,
-                  initiated_by: "parent",
-                  initiator_id: 0,
-                }),
-              });
-              setTxAmount("");
-              setTxMemo("");
-              setTxType("credit");
-              if (resp.ok && selectedChild !== null) {
-                await fetchLedger(selectedChild);
-              } else if (!resp.ok) {
-                const data = await resp.json().catch(() => null);
-                setToast({
-                  message: data?.detail || "Action failed",
-                  error: true,
-                });
-              }
-            }}
-            className="form"
-          >
-            <h4>Add Transaction</h4>
-            <label>
-              Type
-              <select
-                value={txType}
-                onChange={(e) => setTxType(e.target.value)}
+          {childTab === 'actions' && (
+            <>
+              {canAddRecurring && (
+                <form
+                  onSubmit={async (e) => {
+                    e.preventDefault();
+                    const nextDate = new Date(rcNext + 'T00:00:00');
+                    const today = new Date();
+                    today.setHours(0, 0, 0, 0);
+                    if (nextDate < today) {
+                      setToast({ message: 'Next run cannot be in the past', error: true });
+                      return;
+                    }
+                    const resp = await fetch(`${apiUrl}/recurring/child/${selectedChild}`, {
+                      method: 'POST',
+                      headers: {
+                        'Content-Type': 'application/json',
+                        Authorization: `Bearer ${token}`,
+                      },
+                      body: JSON.stringify({
+                        amount: Number(rcAmount),
+                        memo: rcMemo || null,
+                        interval_days: Number(rcInterval),
+                        next_run: rcNext,
+                        type: rcType,
+                      }),
+                    });
+                    if (!resp.ok) {
+                      const data = await resp.json().catch(() => null);
+                      setToast({
+                        message: data?.detail || 'Action failed',
+                        error: true,
+                      });
+                      return;
+                    }
+                    setRcAmount('');
+                    setRcType('debit');
+                    setRcMemo('');
+                    setRcInterval('');
+                    setRcNext('');
+                    fetchCharges(selectedChild);
+                  }}
+                  className="form"
+                >
+                  <h4>Add Recurring Transaction</h4>
+                  <label>
+                    Type
+                    <select value={rcType} onChange={(e) => setRcType(e.target.value)}>
+                      <option value="debit">Debit</option>
+                      <option value="credit">Credit</option>
+                    </select>
+                  </label>
+                  <label>
+                    Amount
+                    <input
+                      type="number"
+                      step="0.01"
+                      value={rcAmount}
+                      onChange={(e) => setRcAmount(e.target.value)}
+                      required
+                    />
+                  </label>
+                  <label>
+                    Memo
+                    <input
+                      value={rcMemo}
+                      onChange={(e) => setRcMemo(e.target.value)}
+                    />
+                  </label>
+                  <label>
+                    Interval days
+                    <input
+                      type="number"
+                      value={rcInterval}
+                      onChange={(e) => setRcInterval(e.target.value)}
+                      required
+                    />
+                  </label>
+                  <label>
+                    Next run
+                    <input
+                      type="date"
+                      value={rcNext}
+                      onChange={(e) => setRcNext(e.target.value)}
+                      required
+                    />
+                  </label>
+                  <button type="submit">Add</button>
+                </form>
+              )}
+              <form
+                onSubmit={async (e) => {
+                  e.preventDefault();
+                  const resp = await fetch(`${apiUrl}/transactions/`, {
+                    method: 'POST',
+                    headers: {
+                      'Content-Type': 'application/json',
+                      Authorization: `Bearer ${token}`,
+                    },
+                    body: JSON.stringify({
+                      child_id: selectedChild,
+                      type: txType,
+                      amount: Number(txAmount),
+                      memo: txMemo || null,
+                      initiated_by: 'parent',
+                      initiator_id: 0,
+                    }),
+                  });
+                  setTxAmount('');
+                  setTxMemo('');
+                  setTxType('credit');
+                  if (resp.ok && selectedChild !== null) {
+                    await fetchLedger(selectedChild);
+                  } else if (!resp.ok) {
+                    const data = await resp.json().catch(() => null);
+                    setToast({
+                      message: data?.detail || 'Action failed',
+                      error: true,
+                    });
+                  }
+                }}
+                className="form"
               >
-                <option value="credit">Credit</option>
-                <option value="debit">Debit</option>
-              </select>
-            </label>
-            <label>
-              Amount
-              <input
-                type="number"
-                step="0.01"
-                value={txAmount}
-                onChange={(e) => setTxAmount(e.target.value)}
-                required
-              />
-            </label>
-            <label>
-              Memo
-              <input
-                value={txMemo}
-                onChange={(e) => setTxMemo(e.target.value)}
-              />
-            </label>
-          <button type="submit">Add</button>
-        </form>
-        <form
-          onSubmit={async (e) => {
-            e.preventDefault();
-            const resp = await fetch(`${apiUrl}/cds/`, {
-              method: "POST",
-              headers: {
-                "Content-Type": "application/json",
-                Authorization: `Bearer ${token}`,
-              },
-              body: JSON.stringify({
-                child_id: selectedChild,
-                amount: Number(cdAmount),
-                interest_rate: Number(cdRate),
-                term_days: Number(cdDays),
-              }),
-            });
-            if (resp.ok) {
-              alert("CD offer sent!");
-            } else {
-              let msg = "Failed to send CD offer";
-              try {
-                const data = await resp.json();
-                if (data.detail) msg = data.detail;
-              } catch {
-                // ignore
-              }
-              alert(msg);
-            }
-            setCdAmount("");
-            setCdRate("");
-            setCdDays("");
-          }}
-          className="form"
-        >
-        <h4>Offer CD</h4>
-        <label>
-          Amount
-          <input
-            type="number"
-            step="0.01"
-            value={cdAmount}
-            onChange={(e) => setCdAmount(e.target.value)}
-            required
-          />
-        </label>
-        <label>
-          Rate
-          <input
-            type="number"
-            step="0.0001"
-            value={cdRate}
-            onChange={(e) => setCdRate(e.target.value)}
-            required
-          />
-        </label>
-        <label>
-          Days
-          <input
-            type="number"
-            value={cdDays}
-            onChange={(e) => setCdDays(e.target.value)}
-            required
-          />
-        </label>
-        <button type="submit">Send</button>
-      </form>
-      </div>
-    )}
+                <h4>Add Transaction</h4>
+                <label>
+                  Type
+                  <select
+                    value={txType}
+                    onChange={(e) => setTxType(e.target.value)}
+                  >
+                    <option value="credit">Credit</option>
+                    <option value="debit">Debit</option>
+                  </select>
+                </label>
+                <label>
+                  Amount
+                  <input
+                    type="number"
+                    step="0.01"
+                    value={txAmount}
+                    onChange={(e) => setTxAmount(e.target.value)}
+                    required
+                  />
+                </label>
+                <label>
+                  Memo
+                  <input
+                    value={txMemo}
+                    onChange={(e) => setTxMemo(e.target.value)}
+                  />
+                </label>
+                <button type="submit">Add</button>
+              </form>
+              <form
+                onSubmit={async (e) => {
+                  e.preventDefault();
+                  const resp = await fetch(`${apiUrl}/cds/`, {
+                    method: 'POST',
+                    headers: {
+                      'Content-Type': 'application/json',
+                      Authorization: `Bearer ${token}`,
+                    },
+                    body: JSON.stringify({
+                      child_id: selectedChild,
+                      amount: Number(cdAmount),
+                      interest_rate: Number(cdRate) / 100,
+                      term_days: Number(cdDays),
+                    }),
+                  });
+                  if (resp.ok) {
+                    alert('CD offer sent!');
+                  } else {
+                    let msg = 'Failed to send CD offer';
+                    try {
+                      const data = await resp.json();
+                      if (data.detail) msg = data.detail;
+                    } catch {
+                      // ignore
+                    }
+                    alert(msg);
+                  }
+                  setCdAmount('');
+                  setCdRate('');
+                  setCdDays('');
+                }}
+                className="form"
+              >
+                <h4>Offer CD</h4>
+                <label>
+                  Amount
+                  <input
+                    type="number"
+                    step="0.01"
+                    value={cdAmount}
+                    onChange={(e) => setCdAmount(e.target.value)}
+                    required
+                  />
+                </label>
+                <label>
+                  Rate (%)
+                  <input
+                    type="number"
+                    step="0.01"
+                    value={cdRate}
+                    onChange={(e) => setCdRate(e.target.value)}
+                    required
+                  />
+                </label>
+                <label>
+                  Days
+                  <input
+                    type="number"
+                    value={cdDays}
+                    onChange={(e) => setCdDays(e.target.value)}
+                    required
+                  />
+                </label>
+                <button type="submit">Send</button>
+              </form>
+            </>
+          )}
+        </div>
+      )}
       {pendingWithdrawals.length > 0 && (
         <div>
           <h4>Pending Withdrawal Requests</h4>

--- a/frontend/src/pages/ParentLoans.tsx
+++ b/frontend/src/pages/ParentLoans.tsx
@@ -58,7 +58,7 @@ export default function ParentLoans({ token, apiUrl, currencySymbol }: Props) {
 
   const approveLoan = async (loanId: number) => {
     const body = {
-      interest_rate: parseFloat(approveRate[loanId] || '0'),
+      interest_rate: parseFloat(approveRate[loanId] || '0') / 100,
       terms: approveTerms[loanId] || undefined,
     }
     await fetch(`${apiUrl}/loans/${loanId}/approve`, {
@@ -100,7 +100,7 @@ export default function ParentLoans({ token, apiUrl, currencySymbol }: Props) {
         Authorization: `Bearer ${token}`,
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({ interest_rate: parseFloat(newRate[loanId] || '0') }),
+      body: JSON.stringify({ interest_rate: parseFloat(newRate[loanId] || '0') / 100 }),
     })
     setNewRate({ ...newRate, [loanId]: '' })
     fetchLoans(selectedChild!)
@@ -142,9 +142,9 @@ export default function ParentLoans({ token, apiUrl, currencySymbol }: Props) {
               {formatCurrency(l.amount, currencySymbol)} for {l.purpose || 'n/a'} - {l.status}
               {['approved', 'active'].includes(l.status) && (
                 <div>
-                  Rate: {l.interest_rate}
+                  Rate: {(l.interest_rate * 100).toFixed(2)}%
                   <input
-                    placeholder="New rate"
+                    placeholder="New rate (%)"
                     value={newRate[l.id] || ''}
                     onChange={e =>
                       setNewRate({ ...newRate, [l.id]: e.target.value })
@@ -156,7 +156,7 @@ export default function ParentLoans({ token, apiUrl, currencySymbol }: Props) {
               {l.status === 'requested' && (
                 <div>
                   <input
-                    placeholder="Interest rate"
+                    placeholder="Interest rate (%)"
                     value={approveRate[l.id] || ''}
                     onChange={e =>
                       setApproveRate({ ...approveRate, [l.id]: e.target.value })


### PR DESCRIPTION
## Summary
- Normalize interest rate inputs and displays to use whole-number percentage notation across settings, promotions, CDs, and loans
- Simplify parent dashboard by listing child actions directly with separate ledger and action views
- Highlight active navigation links in header for clearer orientation

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688fe687ba4c8323a083bf3ea117047c