### PR TITLE
Implement basic messaging system with role-based features

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -45,6 +45,7 @@ async def create_db_and_tables() -> None:
         Permission,
         UserPermissionLink,
         Settings,
+        Message,
     )
 
     async with engine.begin() as conn:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -25,6 +25,7 @@ from app.routes import (
     settings,
     recurring,
     loans,
+    messages,
 )
 from app.database import create_db_and_tables, async_session
 from app.crud import (
@@ -136,6 +137,7 @@ app.include_router(tests.router)
 app.include_router(settings.router)
 app.include_router(recurring.router)
 app.include_router(loans.router)
+app.include_router(messages.router)
 
 
 @app.get("/docs", include_in_schema=False)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -224,3 +224,21 @@ class Settings(SQLModel, table=True):
     overdraft_fee_is_percentage: bool = False
     overdraft_fee_daily: bool = False
     currency_symbol: str = "$"
+
+
+class Message(SQLModel, table=True):
+    """Simple user-to-user message supporting rich text content."""
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    subject: str
+    body: str  # stored as HTML
+    sender_user_id: Optional[int] = Field(default=None, foreign_key="user.id")
+    sender_child_id: Optional[int] = Field(default=None, foreign_key="child.id")
+    recipient_user_id: Optional[int] = Field(default=None, foreign_key="user.id")
+    recipient_child_id: Optional[int] = Field(
+        default=None, foreign_key="child.id"
+    )
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    sender_archived: bool = False
+    recipient_archived: bool = False
+

--- a/backend/app/routes/__init__.py
+++ b/backend/app/routes/__init__.py
@@ -12,6 +12,7 @@ from . import (
     settings,
     recurring,
     loans,
+    messages,
 )
 
 __all__ = [
@@ -26,4 +27,5 @@ __all__ = [
     "tests",
     "recurring",
     "loans",
+    "messages",
 ]

--- a/backend/app/routes/messages.py
+++ b/backend/app/routes/messages.py
@@ -1,0 +1,164 @@
+"""Endpoints for simple user messaging."""
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+from app.database import get_session
+from app.schemas import MessageCreate, MessageRead, BroadcastMessageCreate
+from app.models import User, Child, Message
+from app.auth import get_current_identity, get_current_user
+from app.crud import (
+    create_message,
+    list_inbox,
+    list_sent,
+    archive_message,
+    get_message,
+    get_all_messages,
+    get_child_user_link,
+    get_all_users,
+    get_all_children,
+)
+
+router = APIRouter(prefix="/messages", tags=["messages"])
+
+
+@router.post("/", response_model=MessageRead)
+async def send_message(
+    data: MessageCreate,
+    identity=Depends(get_current_identity),
+    db: AsyncSession = Depends(get_session),
+):
+    sender_type, sender = identity
+    if data.recipient_child_id and data.recipient_user_id:
+        raise HTTPException(status_code=400, detail="Specify only one recipient")
+    if not data.recipient_child_id and not data.recipient_user_id:
+        raise HTTPException(status_code=400, detail="Recipient required")
+
+    msg = Message(subject=data.subject, body=data.body)
+    if sender_type == "user":
+        msg.sender_user_id = sender.id
+        if data.recipient_child_id:
+            if sender.role != "admin":
+                link = await get_child_user_link(
+                    db, sender.id, data.recipient_child_id
+                )
+                if not link:
+                    raise HTTPException(status_code=404, detail="Child not found")
+            msg.recipient_child_id = data.recipient_child_id
+        else:
+            if sender.role != "admin":
+                raise HTTPException(status_code=403, detail="Cannot message user")
+            msg.recipient_user_id = data.recipient_user_id
+    else:  # child sender
+        msg.sender_child_id = sender.id
+        if not data.recipient_user_id or data.recipient_child_id:
+            raise HTTPException(status_code=400, detail="Child must message parent")
+        link = await get_child_user_link(db, data.recipient_user_id, sender.id)
+        if not link:
+            raise HTTPException(status_code=404, detail="Parent not linked")
+        msg.recipient_user_id = data.recipient_user_id
+
+    new_msg = await create_message(db, msg)
+    return new_msg
+
+
+@router.post("/broadcast")
+async def broadcast_message(
+    data: BroadcastMessageCreate,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_session),
+):
+    if current_user.role != "admin":
+        raise HTTPException(status_code=403, detail="Admins only")
+    count = 0
+    recipients = []
+    if data.target in ("all", "parents"):
+        users = await get_all_users(db)
+        for u in users:
+            if u.id == current_user.id:
+                continue
+            if data.target == "all" or u.role != "admin":
+                recipients.append(("user", u.id))
+    if data.target in ("all", "children"):
+        children = await get_all_children(db)
+        for c in children:
+            recipients.append(("child", c.id))
+    for typ, rid in recipients:
+        msg = Message(
+            subject=data.subject,
+            body=data.body,
+            sender_user_id=current_user.id,
+            recipient_user_id=rid if typ == "user" else None,
+            recipient_child_id=rid if typ == "child" else None,
+        )
+        await create_message(db, msg)
+        count += 1
+    return {"count": count}
+
+
+@router.get("/inbox", response_model=list[MessageRead])
+async def inbox(
+    identity=Depends(get_current_identity),
+    db: AsyncSession = Depends(get_session),
+):
+    sender_type, sender = identity
+    if sender_type == "user":
+        return await list_inbox(db, user_id=sender.id)
+    else:
+        return await list_inbox(db, child_id=sender.id)
+
+
+@router.get("/sent", response_model=list[MessageRead])
+async def sent(
+    identity=Depends(get_current_identity),
+    db: AsyncSession = Depends(get_session),
+):
+    sender_type, sender = identity
+    if sender_type == "user":
+        return await list_sent(db, user_id=sender.id)
+    else:
+        return await list_sent(db, child_id=sender.id)
+
+
+@router.get("/archive", response_model=list[MessageRead])
+async def archive_list(
+    identity=Depends(get_current_identity),
+    db: AsyncSession = Depends(get_session),
+):
+    sender_type, sender = identity
+    if sender_type == "user":
+        return await list_inbox(db, user_id=sender.id, archived=True)
+    else:
+        return await list_inbox(db, child_id=sender.id, archived=True)
+
+
+@router.post("/{message_id}/archive", response_model=MessageRead)
+async def archive_msg(
+    message_id: int,
+    identity=Depends(get_current_identity),
+    db: AsyncSession = Depends(get_session),
+):
+    sender_type, sender = identity
+    msg = await get_message(db, message_id)
+    if not msg:
+        raise HTTPException(status_code=404, detail="Not found")
+    if sender_type == "user":
+        if msg.recipient_user_id == sender.id:
+            return await archive_message(db, msg)
+        if msg.sender_user_id == sender.id:
+            return await archive_message(db, msg, as_sender=True)
+    else:
+        if msg.recipient_child_id == sender.id:
+            return await archive_message(db, msg)
+        if msg.sender_child_id == sender.id:
+            return await archive_message(db, msg, as_sender=True)
+    raise HTTPException(status_code=403, detail="Cannot archive")
+
+
+@router.get("/all", response_model=list[MessageRead])
+async def all_messages(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_session),
+):
+    if current_user.role != "admin":
+        raise HTTPException(status_code=403, detail="Admins only")
+    return await get_all_messages(db)

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -39,6 +39,7 @@ from .recurring import (
 from .promotion import Promotion
 from .share import ShareCodeCreate, ShareCodeRead, ParentAccess
 from .loan import LoanCreate, LoanRead, LoanApprove, LoanPayment, LoanRateUpdate
+from .message import MessageCreate, MessageRead, BroadcastMessageCreate
 
 __all__ = [
     "UserCreate",
@@ -79,4 +80,7 @@ __all__ = [
     "LoanApprove",
     "LoanPayment",
     "LoanRateUpdate",
+    "MessageCreate",
+    "MessageRead",
+    "BroadcastMessageCreate",
 ]

--- a/backend/app/schemas/message.py
+++ b/backend/app/schemas/message.py
@@ -1,0 +1,31 @@
+from datetime import datetime
+from typing import Optional
+from pydantic import BaseModel
+
+
+class MessageBase(BaseModel):
+    subject: str
+    body: str
+
+
+class MessageCreate(MessageBase):
+    recipient_user_id: Optional[int] = None
+    recipient_child_id: Optional[int] = None
+
+
+class BroadcastMessageCreate(MessageBase):
+    target: str  # 'all', 'parents', 'children'
+
+
+class MessageRead(MessageBase):
+    id: int
+    sender_user_id: Optional[int] = None
+    sender_child_id: Optional[int] = None
+    recipient_user_id: Optional[int] = None
+    recipient_child_id: Optional[int] = None
+    created_at: datetime
+    sender_archived: bool
+    recipient_archived: bool
+
+    class Config:
+        from_attributes = True

--- a/backend/app/tests/test_messages.py
+++ b/backend/app/tests/test_messages.py
@@ -91,6 +91,12 @@ def test_basic_messaging_flow():
             assert resp.status_code == 200
             child_headers = {"Authorization": f"Bearer {resp.json()['access_token']}"}
 
+            # Child can list linked parents
+            resp = await client.get("/children/me/parents", headers=child_headers)
+            assert resp.status_code == 200
+            assert len(resp.json()) == 1
+            assert resp.json()[0]["user_id"] == parent_id
+
             # Parent sends message to child
             resp = await client.post(
                 "/messages/",

--- a/backend/app/tests/test_messages.py
+++ b/backend/app/tests/test_messages.py
@@ -1,0 +1,149 @@
+import asyncio
+import pathlib
+import sys
+
+from httpx import AsyncClient, ASGITransport
+from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
+from sqlmodel import SQLModel, select
+
+# Allow importing the app package
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
+
+from app.main import app
+from app.database import get_session
+from app.models import Permission, UserPermissionLink, User
+from app.crud import ensure_permissions_exist
+from app.acl import ALL_PERMISSIONS, ROLE_DEFAULT_PERMISSIONS
+
+
+async def _setup_test_db():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    TestSession = async_sessionmaker(engine, expire_on_commit=False)
+
+    async def override_get_session():
+        async with TestSession() as session:
+            yield session
+
+    app.dependency_overrides[get_session] = override_get_session
+
+    async with TestSession() as session:
+        await ensure_permissions_exist(session, ALL_PERMISSIONS)
+
+    return TestSession
+
+
+def test_basic_messaging_flow():
+    async def run():
+        TestSession = await _setup_test_db()
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            # Register admin and parent
+            resp = await client.post(
+                "/register",
+                json={"name": "Admin", "email": "admin@example.com", "password": "pass"},
+            )
+            assert resp.status_code == 200
+            admin_id = resp.json()["id"]
+            resp = await client.post(
+                "/register",
+                json={"name": "Parent", "email": "parent@example.com", "password": "pass"},
+            )
+            assert resp.status_code == 200
+            parent_id = resp.json()["id"]
+
+            # Promote first user to admin and give parent default permissions
+            async with TestSession() as session:
+                admin = await session.get(User, admin_id)
+                admin.role = "admin"
+                for perm_name in ROLE_DEFAULT_PERMISSIONS["parent"]:
+                    result = await session.execute(
+                        select(Permission).where(Permission.name == perm_name)
+                    )
+                    perm = result.scalar_one()
+                    session.add(UserPermissionLink(user_id=parent_id, permission_id=perm.id))
+                await session.commit()
+
+            # Login users
+            resp = await client.post(
+                "/login", json={"email": "admin@example.com", "password": "pass"}
+            )
+            admin_headers = {"Authorization": f"Bearer {resp.json()['access_token']}"}
+            resp = await client.post(
+                "/login", json={"email": "parent@example.com", "password": "pass"}
+            )
+            parent_headers = {"Authorization": f"Bearer {resp.json()['access_token']}"}
+
+            # Parent creates child
+            resp = await client.post(
+                "/children/",
+                headers=parent_headers,
+                json={"first_name": "Kid", "access_code": "KID"},
+            )
+            assert resp.status_code == 200
+            child_id = resp.json()["id"]
+
+            # Child login
+            resp = await client.post(
+                "/children/login", json={"access_code": "KID"}
+            )
+            assert resp.status_code == 200
+            child_headers = {"Authorization": f"Bearer {resp.json()['access_token']}"}
+
+            # Parent sends message to child
+            resp = await client.post(
+                "/messages/",
+                headers=parent_headers,
+                json={
+                    "subject": "Hello",
+                    "body": "<p>Hi Kid</p>",
+                    "recipient_child_id": child_id,
+                },
+            )
+            assert resp.status_code == 200
+            msg_id = resp.json()["id"]
+
+            # Child sees message in inbox
+            resp = await client.get("/messages/inbox", headers=child_headers)
+            assert resp.status_code == 200
+            assert len(resp.json()) == 1
+            assert resp.json()[0]["subject"] == "Hello"
+
+            # Child replies to parent
+            resp = await client.post(
+                "/messages/",
+                headers=child_headers,
+                json={
+                    "subject": "Re",
+                    "body": "<p>Hi Parent</p>",
+                    "recipient_user_id": parent_id,
+                },
+            )
+            assert resp.status_code == 200
+
+            # Parent inbox now has one message
+            resp = await client.get("/messages/inbox", headers=parent_headers)
+            assert len(resp.json()) == 1
+
+            # Admin broadcasts to all
+            resp = await client.post(
+                "/messages/broadcast",
+                headers=admin_headers,
+                json={"subject": "Note", "body": "<p>System</p>", "target": "all"},
+            )
+            assert resp.status_code == 200
+            assert resp.json()["count"] >= 2
+
+            # Inbox counts updated
+            resp = await client.get("/messages/inbox", headers=child_headers)
+            assert len(resp.json()) == 2
+            resp = await client.get("/messages/inbox", headers=parent_headers)
+            assert len(resp.json()) == 2
+
+            # Admin can view all messages
+            resp = await client.get("/messages/all", headers=admin_headers)
+            assert resp.status_code == 200
+            assert len(resp.json()) >= 4
+
+    asyncio.run(run())

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import ChildProfile from './pages/ChildProfile'
 import AdminPanel from './pages/AdminPanel'
 import ChildLoans from './pages/ChildLoans'
 import ParentLoans from './pages/ParentLoans'
+import MessagesPage from './pages/Messages'
 import Header from './components/Header'
 import './App.css'
 import { ToastProvider } from './components/ToastProvider'
@@ -126,6 +127,10 @@ function App() {
                 element={<ChildLoans token={token} childId={childId} apiUrl={apiUrl} currencySymbol={currencySymbol} />}
               />
               <Route
+                path="/child/messages"
+                element={<MessagesPage token={token} apiUrl={apiUrl} isChild={true} isAdmin={false} />}
+              />
+              <Route
                 path="/child/profile"
                 element={<ChildProfile token={token} apiUrl={apiUrl} currencySymbol={currencySymbol} />}
               />
@@ -140,6 +145,10 @@ function App() {
             <Route
               path="/parent/loans"
               element={<ParentLoans token={token} apiUrl={apiUrl} currencySymbol={currencySymbol} />}
+            />
+            <Route
+              path="/messages"
+              element={<MessagesPage token={token} apiUrl={apiUrl} isChild={false} isAdmin={isAdmin} />}
             />
             <Route
               path="/parent/profile"

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -20,12 +20,14 @@ export default function Header({ onLogout, isAdmin, isChild, siteName, onToggleT
               <>
                 <li><NavLink to="/child" className={({isActive}) => isActive ? 'active' : undefined}>Ledger</NavLink></li>
                 <li><NavLink to="/child/loans" className={({isActive}) => isActive ? 'active' : undefined}>Loans</NavLink></li>
+                <li><NavLink to="/child/messages" className={({isActive}) => isActive ? 'active' : undefined}>Messages</NavLink></li>
                 <li><NavLink to="/child/profile" className={({isActive}) => isActive ? 'active' : undefined}>Profile</NavLink></li>
               </>
             ) : (
               <>
                 <li><NavLink to="/" className={({isActive}) => isActive ? 'active' : undefined}>Dashboard</NavLink></li>
                 <li><NavLink to="/parent/loans" className={({isActive}) => isActive ? 'active' : undefined}>Loans</NavLink></li>
+                <li><NavLink to="/messages" className={({isActive}) => isActive ? 'active' : undefined}>Messages</NavLink></li>
                 <li><NavLink to="/parent/profile" className={({isActive}) => isActive ? 'active' : undefined}>Profile</NavLink></li>
               </>
             )}

--- a/frontend/src/pages/Messages.tsx
+++ b/frontend/src/pages/Messages.tsx
@@ -1,0 +1,109 @@
+import { useEffect, useState } from 'react'
+
+interface Message {
+  id: number
+  subject: string
+  body: string
+  created_at: string
+}
+
+interface Props {
+  token: string
+  apiUrl: string
+  isChild: boolean
+  isAdmin: boolean
+}
+
+export default function MessagesPage({ token, apiUrl, isChild, isAdmin }: Props) {
+  const [tab, setTab] = useState<'inbox' | 'sent' | 'archive'>('inbox')
+  const [messages, setMessages] = useState<Message[]>([])
+  const [subject, setSubject] = useState('')
+  const [body, setBody] = useState('')
+  const [recipient, setRecipient] = useState('')
+  const [target, setTarget] = useState<'all' | 'parents' | 'children'>('all')
+
+  const headers = {
+    Authorization: `Bearer ${token}`,
+    'Content-Type': 'application/json'
+  }
+
+  const fetchMessages = async () => {
+    const resp = await fetch(`${apiUrl}/messages/${tab}`, { headers })
+    if (resp.ok) {
+      setMessages(await resp.json())
+    }
+  }
+
+  useEffect(() => {
+    fetchMessages()
+  }, [tab])
+
+  const send = async () => {
+    if (isAdmin) {
+      await fetch(`${apiUrl}/messages/broadcast`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ subject, body, target })
+      })
+    } else {
+      const payload: any = { subject, body }
+      if (isChild) {
+        payload.recipient_user_id = Number(recipient)
+      } else {
+        payload.recipient_child_id = Number(recipient)
+      }
+      await fetch(`${apiUrl}/messages/`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(payload)
+      })
+    }
+    setSubject('')
+    setBody('')
+    setRecipient('')
+    fetchMessages()
+  }
+
+  return (
+    <div className="messages">
+      <h2>Messages</h2>
+      <div>
+        <button onClick={() => setTab('inbox')}>Inbox</button>
+        <button onClick={() => setTab('sent')}>Sent</button>
+        <button onClick={() => setTab('archive')}>Archive</button>
+      </div>
+      <ul>
+        {messages.map(m => (
+          <li key={m.id}>
+            <strong>{m.subject}</strong>
+          </li>
+        ))}
+      </ul>
+      <h3>Compose</h3>
+      {isAdmin ? (
+        <select value={target} onChange={e => setTarget(e.target.value as any)}>
+          <option value="all">All</option>
+          <option value="parents">Parents</option>
+          <option value="children">Children</option>
+        </select>
+      ) : (
+        <input
+          placeholder={isChild ? 'Parent ID' : 'Child ID'}
+          value={recipient}
+          onChange={e => setRecipient(e.target.value)}
+        />
+      )}
+      <input
+        placeholder="Subject"
+        value={subject}
+        onChange={e => setSubject(e.target.value)}
+      />
+      <div
+        className="editor"
+        contentEditable
+        onInput={e => setBody((e.target as HTMLDivElement).innerHTML)}
+      />
+      <button onClick={send}>Send</button>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add Message model and persistence helpers
- expose messaging API for direct, broadcast, and folder views
- create frontend Messages page with simple rich-text editor and navigation links

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689142375b188323b75113984b208cfe