### PR TITLE
Improve messages list with preview and detail view

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -208,6 +208,10 @@
   cursor: pointer;
 }
 
+.message-row {
+  cursor: pointer;
+}
+
 .table-controls {
   display: flex;
   justify-content: space-between;


### PR DESCRIPTION
## Summary
- replace message list with table including sender, subject, preview, date
- add row click to show message body details
- show first 100 chars of message body in list and make rows clickable

## Testing
- `npm run lint`
- `npm run build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689297d2851c8323a312e5cefe259b8f