### PR TITLE
feat(messages): add message detail view with reply

### DIFF
--- a/frontend/src/components/MessageDetail.tsx
+++ b/frontend/src/components/MessageDetail.tsx
@@ -1,0 +1,39 @@
+interface Message {
+  id: number
+  subject: string
+  body: string
+  created_at: string
+  sender_user_id?: number
+  sender_child_id?: number
+  recipient_user_id?: number
+  recipient_child_id?: number
+}
+
+interface Props {
+  message: Message
+  isInbox: boolean
+  getName: (userId?: number, childId?: number) => string
+  onArchive: (id: number) => void
+  onReply: (msg: Message) => void
+}
+
+export default function MessageDetail({ message, isInbox, getName, onArchive, onReply }: Props) {
+  const name = isInbox
+    ? getName(message.sender_user_id, message.sender_child_id)
+    : getName(message.recipient_user_id, message.recipient_child_id)
+  const label = isInbox ? 'From' : 'To'
+
+  return (
+    <div className="detail-panel">
+      <h3>{message.subject}</h3>
+      <p>
+        {`${label} ${name} ${new Date(message.created_at).toLocaleString()}`}
+      </p>
+      <div dangerouslySetInnerHTML={{ __html: message.body }} />
+      <div className="actions">
+        <button onClick={() => onReply(message)}>Reply</button>
+        <button onClick={() => onArchive(message.id)}>Archive</button>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add `MessageDetail` component with reply/archive actions
- show message details in `MessagesPage`
- allow replying to fill compose form and scroll into view

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689299eeee7c8323a0c9b7aef041a79f