### PR TITLE
Add read status to messages and redesign Messages UI

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -241,4 +241,5 @@ class Message(SQLModel, table=True):
     created_at: datetime = Field(default_factory=datetime.utcnow)
     sender_archived: bool = False
     recipient_archived: bool = False
+    read: bool = False
 

--- a/backend/app/schemas/message.py
+++ b/backend/app/schemas/message.py
@@ -26,6 +26,7 @@ class MessageRead(MessageBase):
     created_at: datetime
     sender_archived: bool
     recipient_archived: bool
+    read: bool
 
     class Config:
         from_attributes = True

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -218,7 +218,7 @@
 
 .messages-page {
   display: grid;
-  grid-template-columns: 12rem 1fr 2fr;
+  grid-template-columns: 9rem 10fr 6fr;
   gap: 1rem;
 }
 

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -212,6 +212,29 @@
   cursor: pointer;
 }
 
+.message-row.unread {
+  font-weight: bold;
+}
+
+.messages-page {
+  display: grid;
+  grid-template-columns: 12rem 1fr 2fr;
+  gap: 1rem;
+}
+
+.messages-sidebar {
+  display: flex;
+  flex-direction: column;
+}
+
+.message-list-pane {
+  overflow-y: auto;
+}
+
+.message-detail-pane {
+  overflow-y: auto;
+}
+
 .table-controls {
   display: flex;
   justify-content: space-between;

--- a/frontend/src/components/MessageDetail.tsx
+++ b/frontend/src/components/MessageDetail.tsx
@@ -7,6 +7,7 @@ interface Message {
   sender_child_id?: number
   recipient_user_id?: number
   recipient_child_id?: number
+  read: boolean
 }
 
 interface Props {


### PR DESCRIPTION
## Summary
- add `read` field to Message model and expose via API
- mark messages as read when viewed through new endpoint
- redesign Messages page with sidebar/list/detail layout and unread styling

## Testing
- `./tests/run`


------
https://chatgpt.com/codex/tasks/task_e_68929e89f89883239ef131ef9e84ba73