### PR TITLE
Bootstrap admin account when no users exist

### DIFF
--- a/backend/app/tests/test_child_management.py
+++ b/backend/app/tests/test_child_management.py
@@ -64,6 +64,7 @@ def test_child_management_endpoints():
                 for uid in (p1_id, p2_id):
                     user = await session.get(User, uid)
                     user.status = "active"
+                    user.role = "parent"
                 await session.commit()
 
             # Login

--- a/frontend/src/components/CreateAdminModal.tsx
+++ b/frontend/src/components/CreateAdminModal.tsx
@@ -1,0 +1,41 @@
+import { useState, type FormEvent } from 'react'
+
+interface Props {
+  onSubmit: (name: string, email: string, password: string) => void
+}
+
+export default function CreateAdminModal({ onSubmit }: Props) {
+  const [name, setName] = useState('')
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault()
+    onSubmit(name, email, password)
+  }
+
+  return (
+    <div className="modal-overlay">
+      <div className="modal">
+        <h4>Setup Administrator</h4>
+        <form onSubmit={handleSubmit} className="form">
+          <label>
+            Name
+            <input value={name} onChange={e => setName(e.target.value)} required />
+          </label>
+          <label>
+            Email
+            <input type="email" value={email} onChange={e => setEmail(e.target.value)} required />
+          </label>
+          <label>
+            Password
+            <input type="password" value={password} onChange={e => setPassword(e.target.value)} required />
+          </label>
+          <div className="modal-actions">
+            <button type="submit">Create</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- create `GET /needs-admin` endpoint to detect absence of users
- allow `/register` to create an active admin with full permissions for the first user
- show a setup modal on the login page to register and log in the initial admin

## Testing
- `./tests/run`
- `cd frontend && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6893c1a180408323bc89f4f274fabaa8