### PR TITLE
Improve coupon UI and management

### DIFF
--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -1111,6 +1111,31 @@ async def get_coupon_by_code(db: AsyncSession, code: str) -> Coupon | None:
     return result.scalar_one_or_none()
 
 
+async def get_coupon(db: AsyncSession, coupon_id: int) -> Coupon | None:
+    result = await db.execute(select(Coupon).where(Coupon.id == coupon_id))
+    return result.scalar_one_or_none()
+
+
+async def list_all_coupons(
+    db: AsyncSession, search: str | None = None, scope: str | None = None
+) -> list[Coupon]:
+    stmt = select(Coupon).order_by(Coupon.created_at.desc())
+    if search:
+        like = f"%{search}%"
+        stmt = stmt.where(
+            Coupon.code.ilike(like) | Coupon.memo.ilike(like)
+        )
+    if scope:
+        stmt = stmt.where(Coupon.scope == scope)
+    result = await db.execute(stmt)
+    return result.scalars().all()
+
+
+async def delete_coupon(db: AsyncSession, coupon: Coupon) -> None:
+    await db.delete(coupon)
+    await db.commit()
+
+
 async def list_coupons_by_creator(db: AsyncSession, user_id: int) -> list[Coupon]:
     result = await db.execute(
         select(Coupon)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,7 @@ import ChildLoans from './pages/ChildLoans'
 import ParentLoans from './pages/ParentLoans'
 import ParentCoupons from './pages/ParentCoupons'
 import ChildCoupons from './pages/ChildCoupons'
+import AdminCoupons from './pages/AdminCoupons'
 import MessagesPage from './pages/Messages'
 import Header from './components/Header'
 import './App.css'
@@ -189,10 +190,16 @@ function App() {
           </>
         )}
         {isAdmin && (
-          <Route
-            path="/admin"
-            element={<AdminPanel token={token} apiUrl={apiUrl} onLogout={handleLogout} siteName={siteName} currencySymbol={currencySymbol} onSettingsChange={fetchSettings} />}
-          />
+          <>
+            <Route
+              path="/admin"
+              element={<AdminPanel token={token} apiUrl={apiUrl} onLogout={handleLogout} siteName={siteName} currencySymbol={currencySymbol} onSettingsChange={fetchSettings} />}
+            />
+            <Route
+              path="/admin/coupons"
+              element={<AdminCoupons token={token} apiUrl={apiUrl} currencySymbol={currencySymbol} />}
+            />
+          </>
         )}
         <Route path="*" element={<Navigate to={isChildAccount ? '/child' : '/'} replace />} />
       </Routes>

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -33,7 +33,12 @@ export default function Header({ onLogout, isAdmin, isChild, siteName, onToggleT
                 <li><NavLink to="/parent/profile" className={({isActive}) => isActive ? 'active' : undefined}>Profile</NavLink></li>
               </>
             )}
-          {isAdmin && <li><NavLink to="/admin" className={({isActive}) => isActive ? 'active' : undefined}>Admin</NavLink></li>}
+          {isAdmin && (
+            <>
+              <li><NavLink to="/admin" className={({isActive}) => isActive ? 'active' : undefined}>Admin</NavLink></li>
+              <li><NavLink to="/admin/coupons" className={({isActive}) => isActive ? 'active' : undefined}>Admin Coupons</NavLink></li>
+            </>
+          )}
           <li><button onClick={onToggleTheme}>{theme === 'dark' ? 'Light Mode' : 'Dark Mode'}</button></li>
           <li><button onClick={onLogout}>Logout</button></li>
         </ul>

--- a/frontend/src/pages/AdminCoupons.tsx
+++ b/frontend/src/pages/AdminCoupons.tsx
@@ -1,0 +1,110 @@
+import { useEffect, useState } from "react";
+import { useToast } from "../components/ToastProvider";
+
+interface Coupon {
+  id: number
+  code: string
+  amount: number
+  memo?: string | null
+  expiration?: string | null
+  max_uses: number
+  uses_remaining: number
+  scope: string
+  created_by: number
+}
+
+interface Props {
+  token: string
+  apiUrl: string
+  currencySymbol: string
+}
+
+export default function AdminCoupons({ token, apiUrl, currencySymbol }: Props) {
+  const [coupons, setCoupons] = useState<Coupon[]>([]);
+  const [search, setSearch] = useState("");
+  const [scope, setScope] = useState("all");
+  const { showToast } = useToast();
+
+  const fetchCoupons = async () => {
+    const params = new URLSearchParams();
+    if (search) params.set("search", search);
+    if (scope !== "all") params.set("scope", scope);
+    const resp = await fetch(`${apiUrl}/coupons/all?${params.toString()}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (resp.ok) {
+      setCoupons(await resp.json());
+    }
+  };
+
+  useEffect(() => {
+    fetchCoupons();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [search, scope]);
+
+  async function handleDelete(id: number) {
+    const resp = await fetch(`${apiUrl}/coupons/${id}`, {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (resp.ok) {
+      showToast("Coupon removed");
+      fetchCoupons();
+    } else {
+      showToast("Failed to remove coupon");
+    }
+  }
+
+  return (
+    <div className="p-4 max-w-3xl mx-auto">
+      <h2>All Coupons</h2>
+      <div className="space-x-2 mb-2">
+        <input
+          placeholder="Search"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+        />
+        <select value={scope} onChange={(e) => setScope(e.target.value)}>
+          <option value="all">All Scopes</option>
+          <option value="child">Single Child</option>
+          <option value="my_children">My Children</option>
+          <option value="all_children">All Children</option>
+        </select>
+        <button onClick={fetchCoupons}>Refresh</button>
+      </div>
+      <table className="table-auto w-full">
+        <thead>
+          <tr>
+            <th>Code</th>
+            <th>Scope</th>
+            <th>Amount</th>
+            <th>Uses</th>
+            <th>Expires</th>
+            <th>Creator</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {coupons.map((c) => (
+            <tr key={c.id}>
+              <td>{c.code}</td>
+              <td>{c.scope}</td>
+              <td>
+                {currencySymbol}
+                {c.amount.toFixed(2)}
+              </td>
+              <td>
+                {c.max_uses - c.uses_remaining}/{c.max_uses}
+              </td>
+              <td>{c.expiration ? new Date(c.expiration).toLocaleDateString() : "-"}</td>
+              <td>{c.created_by}</td>
+              <td>
+                <button onClick={() => handleDelete(c.id)}>Delete</button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/src/pages/ChildCoupons.tsx
+++ b/frontend/src/pages/ChildCoupons.tsx
@@ -1,6 +1,18 @@
 import { useEffect, useRef, useState } from "react";
 import { useToast } from "../components/ToastProvider";
 
+interface DetectedCode {
+  rawValue: string;
+}
+
+interface BarcodeDetector {
+  detect(source: CanvasImageSource): Promise<DetectedCode[]>;
+}
+
+interface BDConstructor {
+  new (options: { formats: string[] }): BarcodeDetector;
+}
+
 interface CouponInfo {
   id: number;
   redeemed_at: string;
@@ -47,9 +59,6 @@ export default function ChildCoupons({ token, apiUrl, currencySymbol }: Props) {
         return;
       }
       try {
-        interface BDConstructor {
-          new (options: { formats: string[] }): BarcodeDetector;
-        }
         const Detector = (window as unknown as { BarcodeDetector: BDConstructor }).BarcodeDetector;
         const detector = new Detector({ formats: ["qr_code"] });
         stream = await navigator.mediaDevices.getUserMedia({ video: { facingMode: "environment" } });


### PR DESCRIPTION
## Summary
- add QR scanning and better feedback to child coupon redemption
- enhance parent coupon creation with validation, targets, copy and delete
- support admin coupon management and new backend APIs

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `./tests/run`


------
https://chatgpt.com/codex/tasks/task_e_6893dbeaab1c83239a8eb55a06642fdf