### PR TITLE
Add Bank 101 education modules with quizzes and badges

### DIFF
--- a/backend/app/education_content.py
+++ b/backend/app/education_content.py
@@ -1,0 +1,234 @@
+EDUCATION_MODULES = [
+    {
+        "slug": "interest",
+        "title": "Understanding Interest",
+        "content": "Interest is extra money your savings earn or the cost of borrowing.",
+        "badge": "Interest Ace",
+        "questions": [
+            {
+                "prompt": "What is interest?",
+                "options": [
+                    "Extra money the bank gives you for saving",
+                    "Money you lose",
+                    "A fee for having an account",
+                    "Coins and bills"
+                ],
+                "answer": 0
+            },
+            {
+                "prompt": "Who pays interest on your savings?",
+                "options": [
+                    "Your friend",
+                    "The bank",
+                    "Your pet",
+                    "No one"
+                ],
+                "answer": 1
+            },
+            {
+                "prompt": "A higher interest rate means you earn?",
+                "options": [
+                    "More money",
+                    "Less money",
+                    "No money",
+                    "Fewer coins"
+                ],
+                "answer": 0
+            },
+            {
+                "prompt": "When you borrow money, interest is?",
+                "options": [
+                    "Extra cost you pay back",
+                    "Free candy",
+                    "A gift",
+                    "A tax"
+                ],
+                "answer": 0
+            },
+            {
+                "prompt": "Saving for a long time lets interest?",
+                "options": [
+                    "Grow",
+                    "Disappear",
+                    "Stay the same",
+                    "Go to someone else"
+                ],
+                "answer": 0
+            }
+        ]
+    },
+    {
+        "slug": "cds",
+        "title": "All About CDs",
+        "content": "A Certificate of Deposit (CD) is a special savings account with a set time and rate.",
+        "badge": "CD Star",
+        "questions": [
+            {
+                "prompt": "What does CD stand for?",
+                "options": [
+                    "Certificate of Deposit",
+                    "Cool Dollar",
+                    "Cash Drawer",
+                    "Coin Deposit"
+                ],
+                "answer": 0
+            },
+            {
+                "prompt": "When you put money in a CD you agree to leave it for?",
+                "options": [
+                    "A set amount of time",
+                    "One day",
+                    "Forever",
+                    "Ten minutes"
+                ],
+                "answer": 0
+            },
+            {
+                "prompt": "Taking money out of a CD early might?",
+                "options": [
+                    "Cost a penalty",
+                    "Give more money",
+                    "Do nothing",
+                    "Buy candy"
+                ],
+                "answer": 0
+            },
+            {
+                "prompt": "A benefit of a CD is?",
+                "options": [
+                    "Higher interest rate",
+                    "Lower interest rate",
+                    "Free toys",
+                    "No rules"
+                ],
+                "answer": 0
+            },
+            {
+                "prompt": "When a CD matures you get?",
+                "options": [
+                    "Your money plus interest",
+                    "Nothing",
+                    "Only interest",
+                    "Only your money"
+                ],
+                "answer": 0
+            }
+        ]
+    },
+    {
+        "slug": "borrowing",
+        "title": "Borrowing Basics",
+        "content": "Borrowing lets you use money now and repay it later.",
+        "badge": "Borrowing Boss",
+        "questions": [
+            {
+                "prompt": "Borrowing money means?",
+                "options": [
+                    "Getting money now and paying back later",
+                    "Giving money away",
+                    "Finding money",
+                    "Losing money"
+                ],
+                "answer": 0
+            },
+            {
+                "prompt": "The extra amount you pay back is called?",
+                "options": [
+                    "Interest",
+                    "Bonus",
+                    "Gift",
+                    "Tip"
+                ],
+                "answer": 0
+            },
+            {
+                "prompt": "A loan is?",
+                "options": [
+                    "An agreement to borrow and repay",
+                    "A free gift",
+                    "A game",
+                    "A secret code"
+                ],
+                "answer": 0
+            },
+            {
+                "prompt": "If you don't repay a loan?",
+                "options": [
+                    "You still owe the money",
+                    "You get more money",
+                    "Nothing happens",
+                    "The loan disappears"
+                ],
+                "answer": 0
+            },
+            {
+                "prompt": "You should borrow only when?",
+                "options": [
+                    "You really need something and can repay",
+                    "You want more toys",
+                    "Everyone else borrows",
+                    "Never"
+                ],
+                "answer": 0
+            }
+        ]
+    },
+    {
+        "slug": "saving",
+        "title": "Saving Smart",
+        "content": "Saving means setting money aside so you can use it later.",
+        "badge": "Saving Hero",
+        "questions": [
+            {
+                "prompt": "Saving money means?",
+                "options": [
+                    "Keeping money for later",
+                    "Spending it right away",
+                    "Losing it",
+                    "Throwing it away"
+                ],
+                "answer": 0
+            },
+            {
+                "prompt": "One benefit of saving is?",
+                "options": [
+                    "You can buy something big later",
+                    "Money disappears",
+                    "You get less",
+                    "You owe money"
+                ],
+                "answer": 0
+            },
+            {
+                "prompt": "When you save, your money can?",
+                "options": [
+                    "Grow with interest",
+                    "Shrink",
+                    "Run away",
+                    "Turn into candy"
+                ],
+                "answer": 0
+            },
+            {
+                "prompt": "A good place to keep savings is?",
+                "options": [
+                    "A bank account",
+                    "Your shoe",
+                    "The floor",
+                    "A secret hole"
+                ],
+                "answer": 0
+            },
+            {
+                "prompt": "Saving regularly helps you?",
+                "options": [
+                    "Reach goals faster",
+                    "Forget goals",
+                    "Spend more",
+                    "Lose track"
+                ],
+                "answer": 0
+            }
+        ]
+    }
+]

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -27,6 +27,7 @@ from app.routes import (
     loans,
     messages,
     coupons,
+    education,
 )
 from app.database import create_db_and_tables, async_session
 from app.crud import (
@@ -92,6 +93,9 @@ async def on_startup():
     async with async_session() as session:
         # Ensure any new permissions are inserted into the database on startup.
         await ensure_permissions_exist(session, ALL_PERMISSIONS)
+        from app.crud import ensure_education_content
+
+        await ensure_education_content(session)
     # Run the long‑lived interest calculation loop in the background.
     asyncio.create_task(daily_interest_task())
 
@@ -140,6 +144,7 @@ app.include_router(recurring.router)
 app.include_router(loans.router)
 app.include_router(messages.router)
 app.include_router(coupons.router)
+app.include_router(education.router)
 
 
 @app.get("/docs", include_in_schema=False)

--- a/backend/app/routes/__init__.py
+++ b/backend/app/routes/__init__.py
@@ -14,6 +14,7 @@ from . import (
     loans,
     messages,
     coupons,
+    education,
 )
 
 __all__ = [
@@ -30,4 +31,5 @@ __all__ = [
     "loans",
     "messages",
     "coupons",
+    "education",
 ]

--- a/backend/app/routes/education.py
+++ b/backend/app/routes/education.py
@@ -1,0 +1,128 @@
+"""Routes for educational modules and quizzes."""
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+from app.database import get_session
+from app.auth import get_current_child, get_current_user
+from app.models import Child, User, EducationModule
+from app.schemas import (
+    ModuleRead,
+    QuizSubmission,
+    QuizResult,
+    BadgeRead,
+    ModuleUpdate,
+)
+from app.crud import (
+    get_enabled_modules,
+    get_questions_for_module,
+    award_badge_for_module,
+    get_child_badges,
+)
+from sqlmodel import select
+
+router = APIRouter(prefix="/education", tags=["education"])
+
+
+@router.get("/modules", response_model=list[ModuleRead])
+async def list_modules(
+    child: Child = Depends(get_current_child),
+    db: AsyncSession = Depends(get_session),
+):
+    modules = await get_enabled_modules(db)
+    badges = await get_child_badges(db, child.id)
+    earned_ids = {b.module_id for b in badges if b.module_id is not None}
+    return [
+        ModuleRead(
+            id=m.id,
+            title=m.title,
+            content=m.content,
+            questions=[
+                {"id": q.id, "prompt": q.prompt, "options": q.options}
+                for q in m.questions
+            ],
+            badge_earned=m.id in earned_ids,
+        )
+        for m in modules
+    ]
+
+
+@router.post("/modules/{module_id}/quiz", response_model=QuizResult)
+async def submit_quiz(
+    module_id: int,
+    submission: QuizSubmission,
+    child: Child = Depends(get_current_child),
+    db: AsyncSession = Depends(get_session),
+):
+    questions = await get_questions_for_module(db, module_id)
+    if not questions:
+        raise HTTPException(404, detail="Module not found")
+    score = 0
+    for q, ans in zip(questions, submission.answers):
+        if ans == q.answer_index:
+            score += 1
+    passed = score >= max(1, len(questions) - 1)
+    badge_awarded = False
+    if passed:
+        badge_awarded = await award_badge_for_module(db, child.id, module_id)
+    return QuizResult(score=score, passed=passed, badge_awarded=badge_awarded)
+
+
+@router.get("/badges/me", response_model=list[BadgeRead])
+async def my_badges(
+    child: Child = Depends(get_current_child),
+    db: AsyncSession = Depends(get_session),
+):
+    badges = await get_child_badges(db, child.id)
+    return [BadgeRead(id=b.id, name=b.name, module_id=b.module_id) for b in badges]
+
+
+@router.post("/modules/{module_id}/award/{child_id}")
+async def award_badge(
+    module_id: int,
+    child_id: int,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_session),
+):
+    if user.role != "admin":
+        from app.crud import get_children_by_user
+
+        children = await get_children_by_user(db, user.id)
+        if child_id not in [c.id for c in children]:
+            raise HTTPException(403, detail="Not authorized")
+    awarded = await award_badge_for_module(
+        db, child_id, module_id, awarded_by=user.id, source="manual"
+    )
+    if not awarded:
+        raise HTTPException(400, detail="Badge already awarded")
+    return {"status": "ok"}
+
+
+@router.put("/modules/{module_id}", response_model=ModuleRead)
+async def update_module(
+    module_id: int,
+    data: ModuleUpdate,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_session),
+):
+    if user.role != "admin":
+        raise HTTPException(403, detail="Not authorized")
+    result = await db.execute(
+        select(EducationModule).where(EducationModule.id == module_id)
+    )
+    module = result.scalar_one_or_none()
+    if not module:
+        raise HTTPException(404, detail="Module not found")
+    module.enabled = data.enabled
+    db.add(module)
+    await db.commit()
+    await db.refresh(module)
+    return ModuleRead(
+        id=module.id,
+        title=module.title,
+        content=module.content,
+        questions=[
+            {"id": q.id, "prompt": q.prompt, "options": q.options}
+            for q in module.questions
+        ],
+        badge_earned=False,
+    )

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -46,6 +46,14 @@ from .coupon import (
     CouponRedeem,
     CouponRedemptionRead,
 )
+from .education import (
+    QuizQuestionRead,
+    ModuleRead,
+    QuizSubmission,
+    QuizResult,
+    BadgeRead,
+    ModuleUpdate,
+)
 
 __all__ = [
     "UserCreate",
@@ -93,4 +101,10 @@ __all__ = [
     "CouponRead",
     "CouponRedeem",
     "CouponRedemptionRead",
+    "QuizQuestionRead",
+    "ModuleRead",
+    "QuizSubmission",
+    "QuizResult",
+    "BadgeRead",
+    "ModuleUpdate",
 ]

--- a/backend/app/schemas/education.py
+++ b/backend/app/schemas/education.py
@@ -1,0 +1,30 @@
+from typing import List
+from sqlmodel import SQLModel
+
+class QuizQuestionRead(SQLModel):
+    id: int
+    prompt: str
+    options: List[str]
+
+class ModuleRead(SQLModel):
+    id: int
+    title: str
+    content: str
+    questions: List[QuizQuestionRead]
+    badge_earned: bool = False
+
+class QuizSubmission(SQLModel):
+    answers: List[int]
+
+class QuizResult(SQLModel):
+    score: int
+    passed: bool
+    badge_awarded: bool
+
+class BadgeRead(SQLModel):
+    id: int
+    name: str
+    module_id: int | None = None
+
+class ModuleUpdate(SQLModel):
+    enabled: bool

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,6 +15,7 @@ import ParentCoupons from './pages/ParentCoupons'
 import ChildCoupons from './pages/ChildCoupons'
 import AdminCoupons from './pages/AdminCoupons'
 import MessagesPage from './pages/Messages'
+import ChildBank101 from './pages/ChildBank101'
 import Header from './components/Header'
 import './App.css'
 import { ToastProvider } from './components/ToastProvider'
@@ -154,6 +155,10 @@ function App() {
               <Route
                 path="/child/coupons"
                 element={<ChildCoupons token={token} apiUrl={apiUrl} currencySymbol={currencySymbol} />}
+              />
+              <Route
+                path="/child/bank101"
+                element={<ChildBank101 token={token} apiUrl={apiUrl} />}
               />
               <Route
                 path="/child/messages"

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -21,6 +21,7 @@ export default function Header({ onLogout, isAdmin, isChild, siteName, onToggleT
                 <li><NavLink to="/child" className={({isActive}) => isActive ? 'active' : undefined}>Ledger</NavLink></li>
                 <li><NavLink to="/child/loans" className={({isActive}) => isActive ? 'active' : undefined}>Loans</NavLink></li>
                 <li><NavLink to="/child/coupons" className={({isActive}) => isActive ? 'active' : undefined}>Coupons</NavLink></li>
+                <li><NavLink to="/child/bank101" className={({isActive}) => isActive ? 'active' : undefined}>Bank 101</NavLink></li>
                 <li><NavLink to="/child/messages" className={({isActive}) => isActive ? 'active' : undefined}>Messages</NavLink></li>
                 <li><NavLink to="/child/profile" className={({isActive}) => isActive ? 'active' : undefined}>Profile</NavLink></li>
               </>

--- a/frontend/src/pages/ChildBank101.tsx
+++ b/frontend/src/pages/ChildBank101.tsx
@@ -1,0 +1,108 @@
+import { useEffect, useState } from 'react'
+import { useToast } from '../components/ToastProvider'
+
+interface Props {
+  token: string
+  apiUrl: string
+}
+
+interface QuizQuestion {
+  id: number
+  prompt: string
+  options: string[]
+}
+
+interface Module {
+  id: number
+  title: string
+  content: string
+  questions: QuizQuestion[]
+  badge_earned: boolean
+}
+
+export default function ChildBank101({ token, apiUrl }: Props) {
+  const [modules, setModules] = useState<Module[]>([])
+  const [answers, setAnswers] = useState<Record<number, number[]>>({})
+  const [results, setResults] = useState<Record<number, { score: number; passed: boolean }>>({})
+  const { showToast } = useToast()
+
+  useEffect(() => {
+    const fetchModules = async () => {
+      const resp = await fetch(`${apiUrl}/education/modules`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      if (resp.ok) setModules(await resp.json())
+    }
+    fetchModules()
+  }, [apiUrl, token])
+
+  const setAnswer = (moduleId: number, qIndex: number, option: number) => {
+    setAnswers(prev => {
+      const moduleAnswers = prev[moduleId] ? [...prev[moduleId]] : []
+      moduleAnswers[qIndex] = option
+      return { ...prev, [moduleId]: moduleAnswers }
+    })
+  }
+
+  const submitQuiz = async (module: Module) => {
+    const resp = await fetch(`${apiUrl}/education/modules/${module.id}/quiz`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ answers: answers[module.id] || [] }),
+    })
+    if (resp.ok) {
+      const data = await resp.json()
+      setResults(r => ({ ...r, [module.id]: { score: data.score, passed: data.passed } }))
+      if (data.badge_awarded) {
+        setModules(ms => ms.map(m => (m.id === module.id ? { ...m, badge_earned: true } : m)))
+        showToast('Badge earned!')
+      } else if (data.passed) {
+        showToast('Quiz passed')
+      } else {
+        showToast('Try again', 'error')
+      }
+    }
+  }
+
+  return (
+    <div className="container">
+      <h2>Bank 101</h2>
+      {modules.map(m => (
+        <div key={m.id} className="module">
+          <h3>
+            {m.title} {m.badge_earned && <span title="Badge earned">🏅</span>}
+          </h3>
+          <p className="help-text">{m.content}</p>
+          {m.questions.map((q, qi) => (
+            <div key={q.id} className="question">
+              <p>
+                {qi + 1}. {q.prompt}
+              </p>
+              {q.options.map((opt, oi) => (
+                <label key={oi} style={{ display: 'block' }}>
+                  <input
+                    type="radio"
+                    name={`m${m.id}q${qi}`}
+                    checked={answers[m.id]?.[qi] === oi}
+                    onChange={() => setAnswer(m.id, qi, oi)}
+                  />
+                  {opt}
+                </label>
+              ))}
+            </div>
+          ))}
+          <button onClick={() => submitQuiz(m)}>Submit Quiz</button>
+          {results[m.id] && (
+            <p>
+              Score: {results[m.id].score}/{m.questions.length}{' '}
+              {results[m.id].passed ? '- Passed!' : '- Try again'}
+            </p>
+          )}
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/pages/ChildProfile.tsx
+++ b/frontend/src/pages/ChildProfile.tsx
@@ -22,9 +22,16 @@ interface WithdrawalRequest {
   denial_reason?: string | null
 }
 
+interface Badge {
+  id: number
+  name: string
+  module_id?: number | null
+}
+
 export default function ChildProfile({ token, apiUrl, currencySymbol }: Props) {
   const [data, setData] = useState<ChildProfileData | null>(null)
   const [withdrawals, setWithdrawals] = useState<WithdrawalRequest[]>([])
+  const [badges, setBadges] = useState<Badge[]>([])
 
   useEffect(() => {
     const fetchData = async () => {
@@ -35,8 +42,13 @@ export default function ChildProfile({ token, apiUrl, currencySymbol }: Props) {
       const resp = await fetch(`${apiUrl}/withdrawals/mine`, { headers: { Authorization: `Bearer ${token}` } })
       if (resp.ok) setWithdrawals(await resp.json())
     }
+    const fetchBadges = async () => {
+      const resp = await fetch(`${apiUrl}/education/badges/me`, { headers: { Authorization: `Bearer ${token}` } })
+      if (resp.ok) setBadges(await resp.json())
+    }
     fetchData()
     fetchWithdrawals()
+    fetchBadges()
   }, [token, apiUrl])
 
   if (!data) return <p>Loading...</p>
@@ -62,6 +74,16 @@ export default function ChildProfile({ token, apiUrl, currencySymbol }: Props) {
                 {formatCurrency(w.amount, currencySymbol)}{w.memo ? ` (${w.memo})` : ''} - {w.status}
                 {w.denial_reason ? ` (Reason: ${w.denial_reason})` : ''}
               </li>
+            ))}
+          </ul>
+        </div>
+      )}
+      {badges.length > 0 && (
+        <div>
+          <h3>Your Badges</h3>
+          <ul className="list">
+            {badges.map(b => (
+              <li key={b.id}>{b.name}</li>
             ))}
           </ul>
         </div>


### PR DESCRIPTION
## Summary
- add database models and seed content for modular Bank 101 lessons with badges
- expose `/education` API for modules, quizzes, badge awards, and badge listing
- implement Bank 101 page with interactive quizzes and badge display on profile

## Testing
- `npm run lint`
- `tests/run`


------
https://chatgpt.com/codex/tasks/task_e_68951fb499e48323aaa82132ac3c074b