### PR TITLE
Add chore tracking for parents and kids

### DIFF
--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -19,6 +19,7 @@ from app.models import (
     Account,
     CertificateDeposit,
     RecurringCharge,
+    Chore,
     Permission,
     UserPermissionLink,
     Settings,
@@ -1036,6 +1037,40 @@ async def process_loan_interest(db: AsyncSession) -> None:
     loans = await get_active_loans(db)
     for loan in loans:
         await recalc_loan_interest(db, loan)
+
+
+# --- Chore helpers ------------------------------------------------------
+
+
+async def create_chore(db: AsyncSession, chore: Chore) -> Chore:
+    """Persist a new chore."""
+
+    db.add(chore)
+    await db.commit()
+    await db.refresh(chore)
+    return chore
+
+
+async def get_chore(db: AsyncSession, chore_id: int) -> Chore | None:
+    result = await db.execute(select(Chore).where(Chore.id == chore_id))
+    return result.scalar_one_or_none()
+
+
+async def get_chores_by_child(db: AsyncSession, child_id: int) -> list[Chore]:
+    result = await db.execute(select(Chore).where(Chore.child_id == child_id))
+    return result.scalars().all()
+
+
+async def save_chore(db: AsyncSession, chore: Chore) -> Chore:
+    db.add(chore)
+    await db.commit()
+    await db.refresh(chore)
+    return chore
+
+
+async def delete_chore(db: AsyncSession, chore: Chore) -> None:
+    await db.delete(chore)
+    await db.commit()
 
 
 # --- Messaging helpers ----------------------------------------------------

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -28,6 +28,7 @@ from app.routes import (
     messages,
     coupons,
     education,
+    chores,
 )
 from app.database import create_db_and_tables, async_session
 from app.crud import (
@@ -145,6 +146,7 @@ app.include_router(loans.router)
 app.include_router(messages.router)
 app.include_router(coupons.router)
 app.include_router(education.router)
+app.include_router(chores.router)
 
 
 @app.get("/docs", include_in_schema=False)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -212,6 +212,22 @@ class LoanTransaction(SQLModel, table=True):
     loan: Loan = Relationship(back_populates="transactions")
 
 
+class Chore(SQLModel, table=True):
+    """Task that can earn a child money when completed."""
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    child_id: int = Field(foreign_key="child.id")
+    description: str
+    amount: float
+    interval_days: Optional[int] = None
+    next_due: Optional[date] = None
+    status: str = "pending"  # pending, awaiting_approval, completed, proposed, rejected
+    active: bool = True
+    created_by_child: bool = False
+
+    child: Child = Relationship()
+
+
 class Settings(SQLModel, table=True):
     """Singleton table storing site‑wide configuration values."""
     id: Optional[int] = Field(default=1, primary_key=True)

--- a/backend/app/routes/__init__.py
+++ b/backend/app/routes/__init__.py
@@ -15,6 +15,7 @@ from . import (
     messages,
     coupons,
     education,
+    chores,
 )
 
 __all__ = [
@@ -32,4 +33,5 @@ __all__ = [
     "messages",
     "coupons",
     "education",
+    "chores",
 ]

--- a/backend/app/routes/chores.py
+++ b/backend/app/routes/chores.py
@@ -1,0 +1,238 @@
+import logging
+from datetime import date, timedelta
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_session
+from app.models import Chore, User, Child, Transaction
+from app.schemas import ChoreCreate, ChoreRead, ChoreUpdate
+from app.crud import (
+    create_chore,
+    get_chore,
+    get_chores_by_child,
+    save_chore,
+    delete_chore,
+    create_transaction,
+)
+from app.auth import (
+    get_current_user,
+    get_current_child,
+    get_current_identity,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/chores", tags=["chores"])
+
+
+@router.post("/child/{child_id}", response_model=ChoreRead)
+async def add_chore(
+    child_id: int,
+    data: ChoreCreate,
+    db: AsyncSession = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+):
+    if current_user.role != "admin":
+        from app.crud import get_children_by_user
+
+        children = await get_children_by_user(db, current_user.id)
+        if child_id not in [c.id for c in children]:
+            raise HTTPException(status_code=404, detail="Child not found")
+    chore = Chore(
+        child_id=child_id,
+        description=data.description,
+        amount=data.amount,
+        interval_days=data.interval_days,
+        next_due=data.next_due or date.today(),
+        status="pending",
+        active=True,
+    )
+    new_chore = await create_chore(db, chore)
+    logger.info("Chore created for child %s by user %s", child_id, current_user.id)
+    return new_chore
+
+
+@router.post("/propose", response_model=ChoreRead)
+async def propose_chore(
+    data: ChoreCreate,
+    child: Child = Depends(get_current_child),
+    db: AsyncSession = Depends(get_session),
+):
+    chore = Chore(
+        child_id=child.id,
+        description=data.description,
+        amount=data.amount,
+        interval_days=data.interval_days,
+        next_due=data.next_due or date.today(),
+        status="proposed",
+        active=False,
+        created_by_child=True,
+    )
+    new_chore = await create_chore(db, chore)
+    logger.info("Chore proposed by child %s", child.id)
+    return new_chore
+
+
+@router.get("/child/{child_id}", response_model=List[ChoreRead])
+async def list_chores(
+    child_id: int,
+    db: AsyncSession = Depends(get_session),
+    identity: tuple[str, Child | User] = Depends(get_current_identity),
+):
+    kind, obj = identity
+    if kind == "child":
+        child = obj
+        if child.id != child_id:
+            raise HTTPException(status_code=403, detail="Not authorized")
+    else:
+        user: User = obj
+        if user.role != "admin":
+            from app.crud import get_children_by_user
+
+            children = await get_children_by_user(db, user.id)
+            if child_id not in [c.id for c in children]:
+                raise HTTPException(status_code=404, detail="Child not found")
+    return await get_chores_by_child(db, child_id)
+
+
+@router.get("/mine", response_model=List[ChoreRead])
+async def list_my_chores(
+    child: Child = Depends(get_current_child),
+    db: AsyncSession = Depends(get_session),
+):
+    return await get_chores_by_child(db, child.id)
+
+
+@router.post("/{chore_id}/complete", response_model=ChoreRead)
+async def mark_complete(
+    chore_id: int,
+    child: Child = Depends(get_current_child),
+    db: AsyncSession = Depends(get_session),
+):
+    chore = await get_chore(db, chore_id)
+    if not chore or chore.child_id != child.id:
+        raise HTTPException(status_code=404, detail="Chore not found")
+    if chore.status != "pending":
+        raise HTTPException(status_code=400, detail="Chore not pending")
+    chore.status = "awaiting_approval"
+    updated = await save_chore(db, chore)
+    logger.info("Child %s marked chore %s complete", child.id, chore_id)
+    return updated
+
+
+@router.post("/{chore_id}/approve", response_model=ChoreRead)
+async def approve_chore(
+    chore_id: int,
+    db: AsyncSession = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+):
+    chore = await get_chore(db, chore_id)
+    if not chore:
+        raise HTTPException(status_code=404, detail="Chore not found")
+    if current_user.role != "admin":
+        from app.crud import get_children_by_user
+
+        children = await get_children_by_user(db, current_user.id)
+        if chore.child_id not in [c.id for c in children]:
+            raise HTTPException(status_code=404, detail="Child not found")
+    if chore.status == "awaiting_approval":
+        tx = Transaction(
+            child_id=chore.child_id,
+            type="credit",
+            amount=chore.amount,
+            memo=f"Chore: {chore.description}",
+            initiated_by="parent",
+            initiator_id=current_user.id,
+        )
+        await create_transaction(db, tx)
+        if chore.interval_days:
+            chore.next_due = (chore.next_due or date.today()) + timedelta(days=chore.interval_days)
+            chore.status = "pending"
+            chore.active = True
+        else:
+            chore.status = "completed"
+            chore.active = False
+        updated = await save_chore(db, chore)
+        logger.info("Chore %s approved by user %s", chore_id, current_user.id)
+        return updated
+    if chore.status == "proposed":
+        chore.status = "pending"
+        chore.active = True
+        updated = await save_chore(db, chore)
+        logger.info("Chore %s proposal approved by user %s", chore_id, current_user.id)
+        return updated
+    raise HTTPException(status_code=400, detail="Nothing to approve")
+
+
+@router.post("/{chore_id}/reject", response_model=ChoreRead)
+async def reject_chore(
+    chore_id: int,
+    db: AsyncSession = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+):
+    chore = await get_chore(db, chore_id)
+    if not chore:
+        raise HTTPException(status_code=404, detail="Chore not found")
+    if current_user.role != "admin":
+        from app.crud import get_children_by_user
+
+        children = await get_children_by_user(db, current_user.id)
+        if chore.child_id not in [c.id for c in children]:
+            raise HTTPException(status_code=404, detail="Child not found")
+    if chore.status == "awaiting_approval":
+        chore.status = "pending"
+        updated = await save_chore(db, chore)
+        logger.info("Chore %s completion rejected by user %s", chore_id, current_user.id)
+        return updated
+    if chore.status == "proposed":
+        chore.status = "rejected"
+        chore.active = False
+        updated = await save_chore(db, chore)
+        logger.info("Chore %s proposal rejected by user %s", chore_id, current_user.id)
+        return updated
+    raise HTTPException(status_code=400, detail="Nothing to reject")
+
+
+@router.put("/{chore_id}", response_model=ChoreRead)
+async def update_chore(
+    chore_id: int,
+    data: ChoreUpdate,
+    db: AsyncSession = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+):
+    chore = await get_chore(db, chore_id)
+    if not chore:
+        raise HTTPException(status_code=404, detail="Chore not found")
+    if current_user.role != "admin":
+        from app.crud import get_children_by_user
+
+        children = await get_children_by_user(db, current_user.id)
+        if chore.child_id not in [c.id for c in children]:
+            raise HTTPException(status_code=404, detail="Child not found")
+    for field, value in data.model_dump(exclude_unset=True).items():
+        setattr(chore, field, value)
+    updated = await save_chore(db, chore)
+    logger.info("Chore %s updated by user %s", chore_id, current_user.id)
+    return updated
+
+
+@router.delete("/{chore_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_chore_route(
+    chore_id: int,
+    db: AsyncSession = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+):
+    chore = await get_chore(db, chore_id)
+    if not chore:
+        raise HTTPException(status_code=404, detail="Chore not found")
+    if current_user.role != "admin":
+        from app.crud import get_children_by_user
+
+        children = await get_children_by_user(db, current_user.id)
+        if chore.child_id not in [c.id for c in children]:
+            raise HTTPException(status_code=404, detail="Child not found")
+    await delete_chore(db, chore)
+    logger.info("Chore %s deleted by user %s", chore_id, current_user.id)
+    return None

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -36,6 +36,11 @@ from .recurring import (
     RecurringChargeRead,
     RecurringChargeUpdate,
 )
+from .chore import (
+    ChoreCreate,
+    ChoreRead,
+    ChoreUpdate,
+)
 from .promotion import Promotion
 from .share import ShareCodeCreate, ShareCodeRead, ParentAccess
 from .loan import LoanCreate, LoanRead, LoanApprove, LoanPayment, LoanRateUpdate
@@ -85,6 +90,9 @@ __all__ = [
     "RecurringChargeCreate",
     "RecurringChargeRead",
     "RecurringChargeUpdate",
+    "ChoreCreate",
+    "ChoreRead",
+    "ChoreUpdate",
     "Promotion",
     "ShareCodeCreate",
     "ShareCodeRead",

--- a/backend/app/schemas/chore.py
+++ b/backend/app/schemas/chore.py
@@ -1,0 +1,34 @@
+from datetime import date
+from typing import Optional
+from pydantic import BaseModel
+
+
+class ChoreBase(BaseModel):
+    description: str
+    amount: float
+    interval_days: Optional[int] = None
+    next_due: Optional[date] = None
+
+
+class ChoreCreate(ChoreBase):
+    pass
+
+
+class ChoreRead(ChoreBase):
+    id: int
+    child_id: int
+    status: str
+    active: bool
+    created_by_child: bool
+
+    class Config:
+        from_attributes = True
+
+
+class ChoreUpdate(BaseModel):
+    description: Optional[str] = None
+    amount: Optional[float] = None
+    interval_days: Optional[int] = None
+    next_due: Optional[date] = None
+    active: Optional[bool] = None
+    status: Optional[str] = None

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,6 +16,8 @@ import ChildCoupons from './pages/ChildCoupons'
 import AdminCoupons from './pages/AdminCoupons'
 import MessagesPage from './pages/Messages'
 import ChildBank101 from './pages/ChildBank101'
+import ParentChores from './pages/ParentChores'
+import ChildChores from './pages/ChildChores'
 import Header from './components/Header'
 import './App.css'
 import { ToastProvider } from './components/ToastProvider'
@@ -153,6 +155,10 @@ function App() {
                 element={<ChildLoans token={token} childId={childId} apiUrl={apiUrl} currencySymbol={currencySymbol} />}
               />
               <Route
+                path="/child/chores"
+                element={<ChildChores token={token} apiUrl={apiUrl} currencySymbol={currencySymbol} />}
+              />
+              <Route
                 path="/child/coupons"
                 element={<ChildCoupons token={token} apiUrl={apiUrl} currencySymbol={currencySymbol} />}
               />
@@ -175,6 +181,10 @@ function App() {
             <Route
               path="/"
               element={<ParentDashboard token={token} apiUrl={apiUrl} permissions={permissions} onLogout={handleLogout} currencySymbol={currencySymbol} />}
+            />
+            <Route
+              path="/parent/chores"
+              element={<ParentChores token={token} apiUrl={apiUrl} currencySymbol={currencySymbol} />}
             />
             <Route
               path="/parent/loans"

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -20,6 +20,7 @@ export default function Header({ onLogout, isAdmin, isChild, siteName, onToggleT
               <>
                 <li><NavLink to="/child" className={({isActive}) => isActive ? 'active' : undefined}>Ledger</NavLink></li>
                 <li><NavLink to="/child/loans" className={({isActive}) => isActive ? 'active' : undefined}>Loans</NavLink></li>
+                <li><NavLink to="/child/chores" className={({isActive}) => isActive ? 'active' : undefined}>Chores</NavLink></li>
                 <li><NavLink to="/child/coupons" className={({isActive}) => isActive ? 'active' : undefined}>Coupons</NavLink></li>
                 <li><NavLink to="/child/bank101" className={({isActive}) => isActive ? 'active' : undefined}>Bank 101</NavLink></li>
                 <li><NavLink to="/child/messages" className={({isActive}) => isActive ? 'active' : undefined}>Messages</NavLink></li>
@@ -28,6 +29,7 @@ export default function Header({ onLogout, isAdmin, isChild, siteName, onToggleT
             ) : (
               <>
                 <li><NavLink to="/" className={({isActive}) => isActive ? 'active' : undefined}>Dashboard</NavLink></li>
+                <li><NavLink to="/parent/chores" className={({isActive}) => isActive ? 'active' : undefined}>Chores</NavLink></li>
                 <li><NavLink to="/parent/loans" className={({isActive}) => isActive ? 'active' : undefined}>Loans</NavLink></li>
                 <li><NavLink to="/parent/coupons" className={({isActive}) => isActive ? 'active' : undefined}>Coupons</NavLink></li>
                 <li><NavLink to="/messages" className={({isActive}) => isActive ? 'active' : undefined}>Messages</NavLink></li>

--- a/frontend/src/pages/ChildChores.tsx
+++ b/frontend/src/pages/ChildChores.tsx
@@ -1,0 +1,101 @@
+import { useEffect, useState } from 'react'
+import { formatCurrency } from '../utils/currency'
+import { useToast } from '../components/ToastProvider'
+
+interface Chore {
+  id: number
+  description: string
+  amount: number
+  status: string
+}
+
+interface Props {
+  token: string
+  apiUrl: string
+  currencySymbol: string
+}
+
+export default function ChildChores({ token, apiUrl, currencySymbol }: Props) {
+  const [chores, setChores] = useState<Chore[]>([])
+  const [desc, setDesc] = useState('')
+  const [amount, setAmount] = useState('')
+  const { showToast } = useToast()
+
+  const fetchChores = async () => {
+    const resp = await fetch(`${apiUrl}/chores/mine`, {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+    if (resp.ok) setChores(await resp.json())
+  }
+
+  useEffect(() => {
+    fetchChores()
+  }, [])
+
+  const markDone = async (id: number) => {
+    const resp = await fetch(`${apiUrl}/chores/${id}/complete`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` },
+    })
+    if (resp.ok) {
+      showToast('Chore marked complete')
+      fetchChores()
+    } else showToast('Failed to mark complete', 'error')
+  }
+
+  const propose = async () => {
+    const resp = await fetch(`${apiUrl}/chores/propose`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ description: desc, amount: parseFloat(amount) }),
+    })
+    if (resp.ok) {
+      showToast('Chore proposed')
+      setDesc('')
+      setAmount('')
+      fetchChores()
+    } else showToast('Failed to propose', 'error')
+  }
+
+  return (
+    <div className="container">
+      <h2>Your Chores</h2>
+      {chores.length === 0 ? (
+        <p>No chores yet.</p>
+      ) : (
+        <ul className="list">
+          {chores.map(c => (
+            <li key={c.id}>
+              {c.description} - {formatCurrency(c.amount, currencySymbol)} - {c.status}
+              {c.status === 'pending' && (
+                <button onClick={() => markDone(c.id)} style={{ marginLeft: '0.5rem' }}>
+                  Mark Done
+                </button>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+      <h3>Propose a Chore</h3>
+      <div>
+        <input
+          value={desc}
+          onChange={e => setDesc(e.target.value)}
+          placeholder="Chore description"
+        />
+        <input
+          type="number"
+          value={amount}
+          onChange={e => setAmount(e.target.value)}
+          placeholder="Amount"
+        />
+        <button onClick={propose} disabled={!desc || !amount} style={{ marginLeft: '0.5rem' }}>
+          Submit
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/ParentChores.tsx
+++ b/frontend/src/pages/ParentChores.tsx
@@ -1,0 +1,153 @@
+import { useEffect, useState } from 'react'
+import { formatCurrency } from '../utils/currency'
+import { useToast } from '../components/ToastProvider'
+
+interface Child {
+  id: number
+  first_name: string
+}
+
+interface Chore {
+  id: number
+  description: string
+  amount: number
+  status: string
+  interval_days?: number | null
+}
+
+interface Props {
+  token: string
+  apiUrl: string
+  currencySymbol: string
+}
+
+export default function ParentChores({ token, apiUrl, currencySymbol }: Props) {
+  const [children, setChildren] = useState<Child[]>([])
+  const [selected, setSelected] = useState<number | null>(null)
+  const [chores, setChores] = useState<Chore[]>([])
+  const [desc, setDesc] = useState('')
+  const [amount, setAmount] = useState('')
+  const [interval, setInterval] = useState('')
+  const { showToast } = useToast()
+
+  const fetchChildren = async () => {
+    const resp = await fetch(`${apiUrl}/children/`, {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+    if (resp.ok) setChildren(await resp.json())
+  }
+
+  const fetchChores = async (cid: number) => {
+    const resp = await fetch(`${apiUrl}/chores/child/${cid}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+    if (resp.ok) setChores(await resp.json())
+  }
+
+  useEffect(() => {
+    fetchChildren()
+  }, [])
+
+  useEffect(() => {
+    if (selected !== null) fetchChores(selected)
+  }, [selected])
+
+  const addChore = async () => {
+    if (selected === null) return
+    const resp = await fetch(`${apiUrl}/chores/child/${selected}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ description: desc, amount: parseFloat(amount), interval_days: interval ? parseInt(interval) : null }),
+    })
+    if (resp.ok) {
+      showToast('Chore added')
+      setDesc('')
+      setAmount('')
+      setInterval('')
+      fetchChores(selected)
+    } else showToast('Failed to add chore', 'error')
+  }
+
+  const approve = async (id: number) => {
+    const resp = await fetch(`${apiUrl}/chores/${id}/approve`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` },
+    })
+    if (resp.ok) {
+      showToast('Chore approved')
+      if (selected !== null) fetchChores(selected)
+    }
+  }
+
+  const reject = async (id: number) => {
+    const resp = await fetch(`${apiUrl}/chores/${id}/reject`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` },
+    })
+    if (resp.ok) {
+      showToast('Chore updated')
+      if (selected !== null) fetchChores(selected)
+    }
+  }
+
+  const remove = async (id: number) => {
+    const resp = await fetch(`${apiUrl}/chores/${id}`, {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${token}` },
+    })
+    if (resp.ok && selected !== null) fetchChores(selected)
+  }
+
+  return (
+    <div className="container">
+      <h2>Chores</h2>
+      <div>
+        <select value={selected ?? ''} onChange={e => setSelected(e.target.value ? Number(e.target.value) : null)}>
+          <option value="">Select child</option>
+          {children.map(c => (
+            <option key={c.id} value={c.id}>
+              {c.first_name}
+            </option>
+          ))}
+        </select>
+      </div>
+      {selected !== null && (
+        <>
+          <ul className="list">
+            {chores.map(c => (
+              <li key={c.id}>
+                {c.description} - {formatCurrency(c.amount, currencySymbol)} - {c.status}
+                {c.interval_days ? ` (every ${c.interval_days} days)` : ''}
+                {c.status === 'awaiting_approval' && (
+                  <>
+                    <button onClick={() => approve(c.id)} style={{ marginLeft: '0.5rem' }}>Approve</button>
+                    <button onClick={() => reject(c.id)} style={{ marginLeft: '0.5rem' }}>Reject</button>
+                  </>
+                )}
+                {c.status === 'proposed' && (
+                  <>
+                    <button onClick={() => approve(c.id)} style={{ marginLeft: '0.5rem' }}>Approve</button>
+                    <button onClick={() => reject(c.id)} style={{ marginLeft: '0.5rem' }}>Reject</button>
+                  </>
+                )}
+                <button onClick={() => remove(c.id)} style={{ marginLeft: '0.5rem' }}>Delete</button>
+              </li>
+            ))}
+          </ul>
+          <h3>Add Chore</h3>
+          <div>
+            <input value={desc} onChange={e => setDesc(e.target.value)} placeholder="Description" />
+            <input type="number" value={amount} onChange={e => setAmount(e.target.value)} placeholder="Amount" />
+            <input type="number" value={interval} onChange={e => setInterval(e.target.value)} placeholder="Interval days (optional)" />
+            <button onClick={addChore} disabled={!desc || !amount} style={{ marginLeft: '0.5rem' }}>
+              Add
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add Chore data model and CRUD endpoints
- let children mark chores complete or propose new ones
- new parent and child pages to manage and approve chores

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68977cc86dec83238d209850620e6dff