### PR TITLE
Improve accessibility for dialogs, toasts, and navigation

### DIFF
--- a/frontend/src/components/ConfirmModal.tsx
+++ b/frontend/src/components/ConfirmModal.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useRef } from 'react'
+
 interface Props {
   message: string
   onConfirm: () => void
@@ -5,14 +7,35 @@ interface Props {
 }
 
 export default function ConfirmModal({ message, onConfirm, onCancel }: Props) {
+  const confirmButtonRef = useRef<HTMLButtonElement>(null)
+
+  useEffect(() => {
+    confirmButtonRef.current?.focus()
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onCancel()
+      }
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [onCancel])
+
   return (
     <div className="modal-overlay">
-      <div className="modal">
-        <p>{message}</p>
+      <div
+        className="modal"
+        role="dialog"
+        aria-modal="true"
+        aria-describedby="confirm-modal-message"
+        tabIndex={-1}
+      >
+        <p id="confirm-modal-message">{message}</p>
         <div className="modal-actions">
-          <button onClick={onConfirm}>Yes</button>
+          <button onClick={onConfirm} ref={confirmButtonRef}>
+            Confirm
+          </button>
           <button type="button" className="ml-1" onClick={onCancel}>
-            No
+            Cancel
           </button>
         </div>
       </div>

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -14,7 +14,7 @@ export default function Header({ onLogout, isAdmin, isChild, siteName, onToggleT
   return (
     <header className="header">
       <img src="/unclejon.jpg" alt={`${siteName} Logo`} className="logo" />
-      <nav>
+      <nav aria-label="Main navigation">
         <ul>
           {isChild ? (
               <>
@@ -42,7 +42,14 @@ export default function Header({ onLogout, isAdmin, isChild, siteName, onToggleT
               <li><NavLink to="/admin/coupons" className={({isActive}) => isActive ? 'active' : undefined}>Admin Coupons</NavLink></li>
             </>
           )}
-          <li><button onClick={onToggleTheme}>{theme === 'dark' ? 'Light Mode' : 'Dark Mode'}</button></li>
+          <li>
+            <button
+              onClick={onToggleTheme}
+              aria-label={theme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'}
+            >
+              {theme === 'dark' ? 'Light Mode' : 'Dark Mode'}
+            </button>
+          </li>
           <li><button onClick={onLogout}>Logout</button></li>
         </ul>
       </nav>

--- a/frontend/src/components/ToastProvider.tsx
+++ b/frontend/src/components/ToastProvider.tsx
@@ -27,9 +27,14 @@ export function ToastProvider({ children }: { children: ReactNode }) {
   return (
     <ToastContext.Provider value={{ showToast }}>
       {children}
-      <div className="toast-container">
+      <div className="toast-container" aria-live="polite">
         {toasts.map(t => (
-          <div key={t.id} className={`toast ${t.type === 'error' ? 'error' : ''}`}>
+          <div
+            key={t.id}
+            className={`toast ${t.type === 'error' ? 'error' : ''}`}
+            role={t.type === 'error' ? 'alert' : 'status'}
+            aria-live={t.type === 'error' ? 'assertive' : 'polite'}
+          >
             <span>{t.message}</span>
             <button
               className="toast-close"


### PR DESCRIPTION
## Summary
- Add keyboard and screen reader support to confirmation dialogs with focus management and escape key handling
- Mark toast notifications with appropriate ARIA roles and live regions for assistive technologies
- Label primary navigation and theme toggle button for clearer screen reader guidance

## Testing
- `npm run lint`
- `./tests/run`


------
https://chatgpt.com/codex/tasks/task_e_689780dc634c83239e0cc95b6ef48da3