### PR TITLE
Harden JWT auth with refresh rotation and server-side revocation

### DIFF
--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -1,32 +1,50 @@
 """Authentication and authorization helpers.
 
 This module centralizes password hashing, JWT handling and FastAPI
-dependency utilities for enforcing roles and permissions.  The functions
+dependency utilities for enforcing roles and permissions. The functions
 here are used across route handlers to ensure consistent security
 behavior.
 """
 
-from datetime import datetime, timedelta
-from jose import JWTError, jwt
-from passlib.context import CryptContext
-from fastapi import Depends, HTTPException, status
-from fastapi.security import OAuth2PasswordBearer
-from app.models import User, Child
-from app.database import get_session
-from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import selectinload
-
+from datetime import datetime, timedelta, timezone
+from uuid import uuid4
 import os
 
-SECRET_KEY = os.getenv("SECRET_KEY", "super-secret-key")
+from fastapi import Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer
+from jose import JWTError, jwt
+from passlib.context import CryptContext
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+from sqlmodel import select
+
+from app.database import get_session
+from app.models import Child, RevokedToken, User
+
+SECRET_KEY = os.getenv("SECRET_KEY")
 ALGORITHM = "HS256"
+JWT_ISSUER = os.getenv("JWT_ISSUER", "uncle-jons-bank")
+JWT_AUDIENCE = os.getenv("JWT_AUDIENCE", "uncle-jons-bank-api")
 # Default token expiration in minutes, overridable via environment variable
-ACCESS_TOKEN_EXPIRE_MINUTES = int(
-    os.getenv("ACCESS_TOKEN_EXPIRE_MINUTES", "30")
+ACCESS_TOKEN_EXPIRE_MINUTES = int(os.getenv("ACCESS_TOKEN_EXPIRE_MINUTES", "30"))
+REFRESH_TOKEN_EXPIRE_MINUTES = int(
+    os.getenv("REFRESH_TOKEN_EXPIRE_MINUTES", str(60 * 24 * 14))
 )
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/token")
+
+
+def validate_auth_settings() -> None:
+    """Validate required auth environment settings.
+
+    Called from application startup to fail fast if deployment is insecure.
+    """
+
+    if not SECRET_KEY:
+        raise RuntimeError(
+            "SECRET_KEY is required and must be set before application startup"
+        )
 
 
 def verify_password(plain_password, hashed_password):
@@ -39,9 +57,6 @@ def get_password_hash(password):
     """Hash a password for storage."""
 
     return pwd_context.hash(password)
-
-
-from sqlmodel import select
 
 
 async def authenticate_user(db: AsyncSession, email: str, password: str):
@@ -58,40 +73,179 @@ async def authenticate_user(db: AsyncSession, email: str, password: str):
     return user
 
 
-def create_access_token(data: dict, expires_delta: timedelta | None = None):
-    """Generate a signed JWT token containing ``data``."""
+def _build_token(
+    *,
+    subject: str,
+    token_type: str,
+    expires_delta: timedelta,
+    extra_claims: dict | None = None,
+) -> str:
+    """Generate a signed JWT token with required standard claims."""
 
-    to_encode = data.copy()
-    expire = datetime.utcnow() + (
-        expires_delta or timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
-    )
-    to_encode.update({"exp": expire})
+    validate_auth_settings()
+    now = datetime.now(timezone.utc)
+    to_encode = {
+        "sub": subject,
+        "iss": JWT_ISSUER,
+        "aud": JWT_AUDIENCE,
+        "iat": now,
+        "nbf": now,
+        "exp": now + expires_delta,
+        "jti": str(uuid4()),
+        "type": token_type,
+    }
+    if extra_claims:
+        to_encode.update(extra_claims)
     return jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+
+
+def create_access_token(
+    *,
+    subject: str,
+    expires_delta: timedelta | None = None,
+    extra_claims: dict | None = None,
+) -> str:
+    """Generate a signed short-lived JWT access token."""
+
+    return _build_token(
+        subject=subject,
+        token_type="access",
+        expires_delta=expires_delta
+        or timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES),
+        extra_claims=extra_claims,
+    )
+
+
+def create_refresh_token(
+    *,
+    subject: str,
+    expires_delta: timedelta | None = None,
+    extra_claims: dict | None = None,
+) -> str:
+    """Generate a signed long-lived JWT refresh token."""
+
+    return _build_token(
+        subject=subject,
+        token_type="refresh",
+        expires_delta=expires_delta
+        or timedelta(minutes=REFRESH_TOKEN_EXPIRE_MINUTES),
+        extra_claims=extra_claims,
+    )
+
+
+async def revoke_token(
+    db: AsyncSession,
+    *,
+    jti: str,
+    token_type: str,
+    subject: str,
+    expires_at: datetime,
+    reason: str | None = None,
+) -> RevokedToken:
+    """Persist a revoked token identifier in the server-side block list."""
+
+    existing = await db.execute(select(RevokedToken).where(RevokedToken.jti == jti))
+    record = existing.scalar_one_or_none()
+    if record:
+        return record
+    revoked = RevokedToken(
+        jti=jti,
+        token_type=token_type,
+        subject=subject,
+        expires_at=expires_at,
+        reason=reason,
+    )
+    db.add(revoked)
+    await db.commit()
+    await db.refresh(revoked)
+    return revoked
+
+
+async def is_token_revoked(db: AsyncSession, jti: str) -> bool:
+    """Return ``True`` if a token identifier has been revoked."""
+
+    result = await db.execute(select(RevokedToken.id).where(RevokedToken.jti == jti))
+    return result.first() is not None
+
+
+async def purge_expired_revocations(db: AsyncSession) -> None:
+    """Delete revocation records that have already expired."""
+
+    now = datetime.now(timezone.utc)
+    result = await db.execute(select(RevokedToken).where(RevokedToken.expires_at < now))
+    for record in result.scalars().all():
+        await db.delete(record)
+    await db.commit()
+
+
+async def decode_and_validate_token(
+    db: AsyncSession,
+    token: str,
+    *,
+    expected_type: str | None = "access",
+) -> dict:
+    """Decode JWT, validate standard claims and revocation status."""
+
+    validate_auth_settings()
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Could not validate credentials",
+    )
+    try:
+        payload = jwt.decode(
+            token,
+            SECRET_KEY,
+            algorithms=[ALGORITHM],
+            issuer=JWT_ISSUER,
+            audience=JWT_AUDIENCE,
+            options={"require_exp": True, "require_iat": True, "require_nbf": True},
+        )
+    except JWTError as exc:
+        raise credentials_exception from exc
+
+    sub = payload.get("sub")
+    jti = payload.get("jti")
+    token_type = payload.get("type")
+    if not sub or not jti or not token_type:
+        raise credentials_exception
+    if expected_type and token_type != expected_type:
+        raise credentials_exception
+
+    if await is_token_revoked(db, jti):
+        raise credentials_exception
+    return payload
 
 
 async def get_current_user(
     token: str = Depends(oauth2_scheme),
     db: AsyncSession = Depends(get_session),
 ):
-    credentials_exception = HTTPException(
-        status_code=status.HTTP_401_UNAUTHORIZED,
-        detail="Could not validate credentials",
-    )
+    payload = await decode_and_validate_token(db, token, expected_type="access")
+    sub: str = payload["sub"]
+    if not sub.startswith("user:"):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Could not validate credentials",
+        )
     try:
-        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
-        email: str = payload.get("sub")
-        if email is None:
-            raise credentials_exception
-    except JWTError:
-        raise credentials_exception
+        user_id = int(sub.split(":", 1)[1])
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Could not validate credentials",
+        ) from exc
+
     result = await db.execute(
         select(User)
-        .where(User.email == email)
+        .where(User.id == user_id)
         .options(selectinload(User.permissions))
     )
     user = result.scalar_one_or_none()
     if user is None:
-        raise credentials_exception
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Could not validate credentials",
+        )
     return user
 
 
@@ -132,33 +286,51 @@ async def get_current_identity(
     db: AsyncSession = Depends(get_session),
 ) -> tuple[str, User | Child]:
     """Return ("user", User) or ("child", Child) based on token subject."""
-    credentials_exception = HTTPException(
+
+    payload = await decode_and_validate_token(db, token, expected_type="access")
+    sub: str = payload["sub"]
+
+    if sub.startswith("child:"):
+        try:
+            child_id = int(sub.split(":", 1)[1])
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Could not validate credentials",
+            ) from exc
+        child = await get_child_by_id(db, child_id)
+        if child is None:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Could not validate credentials",
+            )
+        return "child", child
+
+    if sub.startswith("user:"):
+        try:
+            user_id = int(sub.split(":", 1)[1])
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Could not validate credentials",
+            ) from exc
+        result = await db.execute(
+            select(User)
+            .where(User.id == user_id)
+            .options(selectinload(User.permissions))
+        )
+        user = result.scalar_one_or_none()
+        if user is None:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Could not validate credentials",
+            )
+        return "user", user
+
+    raise HTTPException(
         status_code=status.HTTP_401_UNAUTHORIZED,
         detail="Could not validate credentials",
     )
-    try:
-        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
-        sub: str = payload.get("sub")
-        if not sub:
-            raise credentials_exception
-        if sub.startswith("child:"):
-            child_id = int(sub.split(":", 1)[1])
-            child = await get_child_by_id(db, child_id)
-            if child is None:
-                raise credentials_exception
-            return "child", child
-        else:
-            result = await db.execute(
-                select(User)
-                .where(User.email == sub)
-                .options(selectinload(User.permissions))
-            )
-            user = result.scalar_one_or_none()
-            if user is None:
-                raise credentials_exception
-            return "user", user
-    except (JWTError, ValueError):
-        raise credentials_exception
 
 
 async def get_child_by_id(db: AsyncSession, child_id: int):
@@ -170,19 +342,24 @@ async def get_current_child(
     token: str = Depends(oauth2_scheme),
     db: AsyncSession = Depends(get_session),
 ):
-    credentials_exception = HTTPException(
-        status_code=status.HTTP_401_UNAUTHORIZED,
-        detail="Could not validate credentials",
-    )
+    payload = await decode_and_validate_token(db, token, expected_type="access")
+    sub: str = payload["sub"]
+    if not sub.startswith("child:"):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Could not validate credentials",
+        )
     try:
-        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
-        sub: str = payload.get("sub")
-        if not sub or not sub.startswith("child:"):
-            raise credentials_exception
         child_id = int(sub.split(":", 1)[1])
-    except (JWTError, ValueError):
-        raise credentials_exception
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Could not validate credentials",
+        ) from exc
     child = await get_child_by_id(db, child_id)
     if child is None:
-        raise credentials_exception
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Could not validate credentials",
+        )
     return child

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -46,6 +46,7 @@ async def create_db_and_tables() -> None:
         UserPermissionLink,
         Settings,
         Message,
+        RevokedToken,
     )
 
     async with engine.begin() as conn:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -43,6 +43,7 @@ from app.crud import (
 )
 from app.models import Child
 from app.acl import ALL_PERMISSIONS
+from app.auth import validate_auth_settings
 from sqlmodel import select
 import asyncio
 from datetime import date
@@ -90,6 +91,7 @@ app.add_middleware(
 async def on_startup():
     """Initialize the database and kick off background tasks."""
 
+    validate_auth_settings()
     await create_db_and_tables()
     async with async_session() as session:
         # Ensure any new permissions are inserted into the database on startup.

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -345,3 +345,15 @@ class ChildBadge(SQLModel, table=True):
     child: Child = Relationship()
     badge: Badge = Relationship(back_populates="child_links")
 
+
+
+class RevokedToken(SQLModel, table=True):
+    """Server-side revocation record for JWT access/refresh tokens."""
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    jti: str = Field(unique=True, index=True)
+    token_type: str
+    subject: str
+    reason: Optional[str] = None
+    revoked_at: datetime = Field(default_factory=datetime.utcnow)
+    expires_at: datetime

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -2,24 +2,49 @@
 import logging
 """Authentication endpoints: login, token generation and registration."""
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Body, Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordRequestForm
+from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
+from sqlalchemy import func
+
 from app.auth import (
-    create_access_token,
-    verify_password,
     authenticate_user,
+    create_access_token,
+    create_refresh_token,
+    decode_and_validate_token,
+    revoke_token,
+    verify_password,
+    oauth2_scheme,
 )
 from app.database import get_session
 from app.models import User
 from app.crud import get_settings, create_user
-
-from sqlmodel import select
-from sqlalchemy import func
 from app.schemas.user import UserCreate, UserResponse, UserLogin
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
+
+
+class RefreshRequest(BaseModel):
+    refresh_token: str
+
+
+class LogoutRequest(BaseModel):
+    refresh_token: str | None = None
+
+
+def _token_pair_for_subject(subject: str) -> dict[str, str]:
+    access_token = create_access_token(subject=subject)
+    refresh_token = create_refresh_token(subject=subject)
+    return {
+        "access_token": access_token,
+        "refresh_token": refresh_token,
+        "token_type": "bearer",
+    }
 
 
 @router.post("/token")
@@ -49,9 +74,7 @@ async def login_for_access_token(
             },
         )
     logger.info("User %s logged in via OAuth form", user.email)
-    access_token = create_access_token(data={"sub": user.email})
-    return {"access_token": access_token, "token_type": "bearer"}
-
+    return _token_pair_for_subject(f"user:{user.id}")
 
 
 @router.post("/login")
@@ -79,8 +102,80 @@ async def login(user_in: UserLogin, db: AsyncSession = Depends(get_session)):
             },
         )
     logger.info("User %s logged in", user.email)
-    access_token = create_access_token(data={"sub": user.email})
-    return {"access_token": access_token, "token_type": "bearer"}
+    return _token_pair_for_subject(f"user:{user.id}")
+
+
+@router.post("/refresh")
+async def refresh_access_token(
+    payload: RefreshRequest,
+    db: AsyncSession = Depends(get_session),
+):
+    """Rotate refresh tokens and issue a new access/refresh token pair."""
+
+    refresh_payload = await decode_and_validate_token(
+        db,
+        payload.refresh_token,
+        expected_type="refresh",
+    )
+    await revoke_token(
+        db,
+        jti=refresh_payload["jti"],
+        token_type="refresh",
+        subject=refresh_payload["sub"],
+        expires_at=datetime.fromtimestamp(refresh_payload["exp"], tz=timezone.utc),
+        reason="rotated",
+    )
+    return _token_pair_for_subject(refresh_payload["sub"])
+
+
+@router.post("/logout")
+async def logout(
+    request: LogoutRequest | None = Body(default=None),
+    access_token: str = Depends(oauth2_scheme),
+    db: AsyncSession = Depends(get_session),
+):
+    """Revoke current access token and optionally the provided refresh token."""
+
+    access_payload = await decode_and_validate_token(
+        db,
+        access_token,
+        expected_type="access",
+    )
+    await revoke_token(
+        db,
+        jti=access_payload["jti"],
+        token_type="access",
+        subject=access_payload["sub"],
+        expires_at=datetime.fromtimestamp(access_payload["exp"], tz=timezone.utc),
+        reason="logout",
+    )
+
+    if request and request.refresh_token:
+        refresh_payload = await decode_and_validate_token(
+            db,
+            request.refresh_token,
+            expected_type="refresh",
+        )
+        if refresh_payload["sub"] != access_payload["sub"]:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail={
+                    "code": "auth_subject_mismatch",
+                    "message": "Refresh token does not belong to current subject",
+                },
+            )
+        await revoke_token(
+            db,
+            jti=refresh_payload["jti"],
+            token_type="refresh",
+            subject=refresh_payload["sub"],
+            expires_at=datetime.fromtimestamp(
+                refresh_payload["exp"], tz=timezone.utc
+            ),
+            reason="logout",
+        )
+
+    return {"detail": "Logged out"}
 
 
 @router.get("/needs-admin")
@@ -89,6 +184,7 @@ async def needs_admin(db: AsyncSession = Depends(get_session)):
 
     result = await db.execute(select(func.count()).select_from(User))
     return {"needs_admin": result.scalar() == 0}
+
 
 @router.post("/register", response_model=UserResponse)
 async def register(user_in: UserCreate, db: AsyncSession = Depends(get_session)):
@@ -130,4 +226,3 @@ async def register(user_in: UserCreate, db: AsyncSession = Depends(get_session))
         " as initial admin" if is_first_user else "",
     )
     return new_user
-

--- a/backend/app/routes/children.py
+++ b/backend/app/routes/children.py
@@ -40,6 +40,7 @@ from app.auth import (
     get_current_user,
     require_role,
     create_access_token,
+    create_refresh_token,
     require_permissions,
     get_current_identity,
 )
@@ -469,5 +470,10 @@ async def child_login(
         raise HTTPException(status_code=401, detail="Invalid access code")
     if child.account_frozen:
         raise HTTPException(status_code=403, detail="Account is frozen")
-    token = create_access_token(data={"sub": f"child:{child.id}"})
-    return {"access_token": token, "token_type": "bearer"}
+    access_token = create_access_token(subject=f"child:{child.id}")
+    refresh_token = create_refresh_token(subject=f"child:{child.id}")
+    return {
+        "access_token": access_token,
+        "refresh_token": refresh_token,
+        "token_type": "bearer",
+    }

--- a/backend/app/tests/test_auth_security.py
+++ b/backend/app/tests/test_auth_security.py
@@ -1,0 +1,231 @@
+import asyncio
+import importlib
+import os
+import pathlib
+import sys
+from datetime import timedelta
+
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlmodel import SQLModel, select, delete
+
+# Ensure auth config exists before importing app modules.
+os.environ.setdefault("SECRET_KEY", "test-secret-key")
+os.environ.setdefault("JWT_ISSUER", "test-suite")
+os.environ.setdefault("JWT_AUDIENCE", "test-audience")
+
+# Allow importing the app package
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
+
+from app.main import app
+from app.database import get_session
+from app.models import Child, ChildUserLink, Permission, User, UserPermissionLink
+from app.crud import ensure_permissions_exist
+from app.acl import ALL_PERMISSIONS, ROLE_DEFAULT_PERMISSIONS, PERM_SEND_MESSAGE
+from app.auth import create_access_token, create_refresh_token
+
+
+async def _setup_test_db():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    test_session = async_sessionmaker(engine, expire_on_commit=False)
+
+    async def override_get_session():
+        async with test_session() as session:
+            yield session
+
+    app.dependency_overrides[get_session] = override_get_session
+
+    async with test_session() as session:
+        await ensure_permissions_exist(session, ALL_PERMISSIONS)
+
+    return test_session
+
+
+async def _seed_user(
+    test_session,
+    *,
+    email: str,
+    role: str,
+    status: str = "active",
+) -> int:
+    async with test_session() as session:
+        user = User(name=email.split("@")[0], email=email, password_hash="noop", role=role, status=status)
+        session.add(user)
+        await session.commit()
+        await session.refresh(user)
+        return user.id
+
+
+def test_auth_settings_require_secret_key():
+    import app.auth as auth
+
+    old_value = os.environ.pop("SECRET_KEY", None)
+    importlib.reload(auth)
+    try:
+        try:
+            auth.validate_auth_settings()
+            assert False, "Expected RuntimeError when SECRET_KEY is unset"
+        except RuntimeError:
+            pass
+    finally:
+        if old_value is not None:
+            os.environ["SECRET_KEY"] = old_value
+        importlib.reload(auth)
+
+
+def test_expired_access_token_is_rejected():
+    async def run():
+        test_session = await _setup_test_db()
+        user_id = await _seed_user(
+            test_session,
+            email="expired@example.com",
+            role="parent",
+            status="active",
+        )
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            token = create_access_token(
+                subject=f"user:{user_id}", expires_delta=timedelta(seconds=1)
+            )
+            await asyncio.sleep(2)
+            resp = await client.get(
+                "/users/me", headers={"Authorization": f"Bearer {token}"}
+            )
+            assert resp.status_code == 401
+
+    asyncio.run(run())
+
+
+def test_role_and_permission_enforcement():
+    async def run():
+        test_session = await _setup_test_db()
+        admin_id = await _seed_user(
+            test_session,
+            email="admin-auth@example.com",
+            role="admin",
+            status="active",
+        )
+        parent_id = await _seed_user(
+            test_session,
+            email="parent-auth@example.com",
+            role="parent",
+            status="active",
+        )
+
+        async with test_session() as session:
+            child = Child(first_name="Kid", access_code="AUTHKID")
+            session.add(child)
+            await session.commit()
+            await session.refresh(child)
+            session.add(
+                ChildUserLink(
+                    user_id=parent_id,
+                    child_id=child.id,
+                    permissions=ROLE_DEFAULT_PERMISSIONS["parent"],
+                    is_owner=True,
+                )
+            )
+            await session.commit()
+            child_id = child.id
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            admin_headers = {
+                "Authorization": f"Bearer {create_access_token(subject=f'user:{admin_id}') }"
+            }
+            parent_headers = {
+                "Authorization": f"Bearer {create_access_token(subject=f'user:{parent_id}') }"
+            }
+
+            # Role check: non-admin cannot access admin-only route.
+            resp = await client.get("/admin/users", headers=parent_headers)
+            assert resp.status_code == 403
+            resp = await client.get("/admin/users", headers=admin_headers)
+            assert resp.status_code == 200
+
+            # Permission check: remove messaging permission and ensure it is blocked.
+            async with test_session() as session:
+                result = await session.execute(
+                    select(Permission).where(Permission.name == PERM_SEND_MESSAGE)
+                )
+                perm = result.scalar_one()
+                await session.execute(
+                    delete(UserPermissionLink).where(
+                        UserPermissionLink.user_id == parent_id,
+                        UserPermissionLink.permission_id == perm.id,
+                    )
+                )
+                await session.commit()
+
+            resp = await client.post(
+                "/messages/",
+                headers=parent_headers,
+                json={
+                    "subject": "blocked",
+                    "body": "<p>x</p>",
+                    "recipient_child_id": child_id,
+                },
+            )
+            assert resp.status_code == 403
+
+    asyncio.run(run())
+
+
+def test_refresh_rotation_and_revoked_rejection():
+    async def run():
+        test_session = await _setup_test_db()
+        user_id = await _seed_user(
+            test_session,
+            email="refresh@example.com",
+            role="parent",
+            status="active",
+        )
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            access_token = create_access_token(subject=f"user:{user_id}")
+            refresh_token = create_refresh_token(subject=f"user:{user_id}")
+
+            refresh_resp = await client.post(
+                "/refresh", json={"refresh_token": refresh_token}
+            )
+            assert refresh_resp.status_code == 200
+            rotated_access = refresh_resp.json()["access_token"]
+            rotated_refresh = refresh_resp.json()["refresh_token"]
+
+            # Old refresh token was rotated and revoked.
+            reused_resp = await client.post(
+                "/refresh", json={"refresh_token": refresh_token}
+            )
+            assert reused_resp.status_code == 401
+
+            # Logout should revoke both current access and refresh tokens.
+            logout_resp = await client.post(
+                "/logout",
+                headers={"Authorization": f"Bearer {rotated_access}"},
+                json={"refresh_token": rotated_refresh},
+            )
+            assert logout_resp.status_code == 200
+
+            revoked_access = await client.get(
+                "/users/me",
+                headers={"Authorization": f"Bearer {rotated_access}"},
+            )
+            assert revoked_access.status_code == 401
+
+            revoked_refresh = await client.post(
+                "/refresh", json={"refresh_token": rotated_refresh}
+            )
+            assert revoked_refresh.status_code == 401
+
+            # Original access token has never been revoked and remains usable.
+            still_valid = await client.get(
+                "/users/me",
+                headers={"Authorization": f"Bearer {access_token}"},
+            )
+            assert still_valid.status_code == 200
+
+    asyncio.run(run())

--- a/backend/app/tests/test_token_expiration.py
+++ b/backend/app/tests/test_token_expiration.py
@@ -1,15 +1,26 @@
+import os
 from datetime import datetime
 import importlib
 from jose import jwt
 
 
 def test_access_token_expiration_respects_env(monkeypatch):
+    monkeypatch.setenv("SECRET_KEY", "test-secret")
+    monkeypatch.setenv("JWT_ISSUER", "test-issuer")
+    monkeypatch.setenv("JWT_AUDIENCE", "test-audience")
     monkeypatch.setenv("ACCESS_TOKEN_EXPIRE_MINUTES", "1")
+
     import app.auth as auth
     importlib.reload(auth)
 
-    token = auth.create_access_token(data={"sub": "test"})
-    decoded = jwt.decode(token, auth.SECRET_KEY, algorithms=[auth.ALGORITHM])
+    token = auth.create_access_token(subject="user:1")
+    decoded = jwt.decode(
+        token,
+        auth.SECRET_KEY,
+        algorithms=[auth.ALGORITHM],
+        issuer=auth.JWT_ISSUER,
+        audience=auth.JWT_AUDIENCE,
+    )
     exp = datetime.utcfromtimestamp(decoded["exp"])
     delta = exp - datetime.utcnow()
     assert 45 <= delta.total_seconds() <= 75

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,6 +8,7 @@ uvicorn
 # Database layer
 sqlmodel
 sqlalchemy
+greenlet
 aiosqlite
 httpx
 email-validator

--- a/docs/security-operations.md
+++ b/docs/security-operations.md
@@ -1,0 +1,54 @@
+# Security Operations: Authentication Tokens
+
+This document describes production auth configuration and JWT key rotation for Uncle Jon's Bank.
+
+## Required environment variables
+
+Set these in all non-local environments:
+
+- `SECRET_KEY` (**required**): HMAC signing key for JWTs. The API now fails startup if this is missing.
+- `JWT_ISSUER` (recommended, default: `uncle-jons-bank`): expected `iss` claim.
+- `JWT_AUDIENCE` (recommended, default: `uncle-jons-bank-api`): expected `aud` claim.
+- `ACCESS_TOKEN_EXPIRE_MINUTES` (optional, default: `30`): access token lifetime.
+- `REFRESH_TOKEN_EXPIRE_MINUTES` (optional, default: `20160` / 14 days): refresh token lifetime.
+
+## Claims enforced by the API
+
+All tokens are signed with `HS256` and validated against:
+
+- `sub` (`user:{id}` or `child:{id}`)
+- `iss`
+- `aud`
+- `iat`
+- `nbf`
+- `exp`
+- `jti`
+- `type` (`access` or `refresh`)
+
+## Refresh + revocation model
+
+- `/login`, `/token`, and `/children/login` return both access and refresh tokens.
+- `/refresh` rotates refresh tokens (old refresh token is revoked immediately).
+- `/logout` revokes the current access token and optionally the matching refresh token.
+- Revoked `jti` values are persisted in the `revokedtoken` table and rejected on all authenticated requests.
+
+## Rotation procedure for `SECRET_KEY`
+
+Because this project currently uses symmetric signing (`HS256`), key rotation invalidates all outstanding tokens.
+
+1. **Prepare maintenance window** and notify users that re-authentication will be required.
+2. **Generate a new strong random key** and store it in your secret manager.
+3. **Update `SECRET_KEY`** in deployment configuration.
+4. **Restart API instances** so startup validation picks up the new key.
+5. **Force logout behavior** (optional but recommended): call `/logout` for active sessions if you track them externally.
+6. **Verify**:
+   - Old tokens return `401`.
+   - New logins receive valid access + refresh tokens.
+   - `/refresh` and `/logout` continue to work.
+
+## Incident response (suspected token compromise)
+
+1. Rotate `SECRET_KEY` immediately.
+2. Invalidate all sessions (users must log in again).
+3. Review access logs for suspicious use of `/refresh` and privileged endpoints.
+4. Shorten token lifetimes temporarily via env vars until incident is resolved.


### PR DESCRIPTION
### Motivation
- Remove an insecure hardcoded JWT fallback and fail fast at startup when `SECRET_KEY` is not set to avoid accidental insecure deployments.
- Use stable token subjects (`user:{id}` / `child:{id}`) so identities are robust to email changes and easier to validate server-side.
- Enforce standard JWT claims and add refresh/rotation plus server-side revocation to enable safe long‑lived sessions and immediate logout/rotation semantics.
- Add focused tests and a runbook so operators can understand required env vars and key rotation procedures.

### Description
- Require `SECRET_KEY` at startup via `validate_auth_settings()` and remove the old hardcoded fallback; call this from the application startup sequence (`app.main`).
- Replace ad-hoc JWT encoding with `_build_token()` and add `iss`, `aud`, `iat`, `nbf`, `exp`, `jti` and `type` claims; switch token builders to `create_access_token(subject=...)` and `create_refresh_token(subject=...)` (`backend/app/auth.py`).
- Add `decode_and_validate_token()` which validates standard claims, token `type`, and checks revocation before returning the payload, and update `get_current_user`, `get_current_identity`, and `get_current_child` to consume `sub` values like `user:{id}` / `child:{id}`.
- Introduce a `RevokedToken` model and include it in DB creation/migrations, plus revocation helper functions `revoke_token`, `is_token_revoked`, and `purge_expired_revocations` (`backend/app/models.py`, `backend/app/database.py`, `backend/app/auth.py`).
- Add refresh semantics and endpoints: `/login`, `/token`, and `/children/login` now return access + refresh tokens; `/refresh` rotates (revokes) the old refresh token and issues a new pair; `/logout` revokes the current access token and an optional refresh token (`backend/app/routes/auth.py`, `backend/app/routes/children.py`).
- Add auth-focused tests that cover missing-secret startup behavior, token expiry rejection, role/permission enforcement, refresh rotation, and revoked-token rejection, and update the token expiration test to validate the new claims (`backend/app/tests/test_auth_security.py`, `backend/app/tests/test_token_expiration.py`).
- Add `docs/security-operations.md` documenting required env vars, claims enforcement, refresh/revocation model, and a `SECRET_KEY` rotation procedure.

### Testing
- Ran the auth test suite with: `SECRET_KEY=test-secret JWT_ISSUER=test-suite JWT_AUDIENCE=test-audience pytest -q backend/app/tests/test_token_expiration.py backend/app/tests/test_auth_security.py` and the selected tests passed (`5 passed`, warnings only).
- Local integration checks exercised login/refresh/logout flows and confirmed revoked tokens are rejected and rotated refresh tokens cannot be reused via the new tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca7ff43bdc8323ae041acde2fc7d50)